### PR TITLE
Post-processing enhancement

### DIFF
--- a/kernel/include/Couplings/Coupling.hpp
+++ b/kernel/include/Couplings/Coupling.hpp
@@ -42,12 +42,14 @@ class Coupling {
 
   std::vector<std::tuple<std::string, std::vector<std::tuple<std::string, bool, double>>>>
       pb_convergence_;
+  void check_duplicate_problem_name();
 
  public:
   explicit Coupling(const std::string& name, Args... problems);
   std::string get_name();
-
+  void set_name(const std::string& new_name);
   void get_tree();
+  void check_duplicate_post_processing_directory(std::size_t nb_couplings);
   void initialize(const int& iter, const double& initial_time, const double time_step);
   void execute(const int& iter, double& next_time, const double& current_time,
                const double& current_time_step);

--- a/kernel/include/Couplings/Coupling.tpp
+++ b/kernel/include/Couplings/Coupling.tpp
@@ -31,24 +31,27 @@
 #include <utility>
 #include <vector>
 
+#include "Utils/UtilsForData.hpp"
 #include "Utils/UtilsForDebug.hpp"
 #include "mfem.hpp"  // NOLINT [no include the directory when naming mfem include file]
 
 /**
  * @brief Construct a new Coupling< Args...>:: Coupling object
  *
- * @tparam Args
+ * @tparam Args Types of the problems stored in the coupling.
  * @param problems
  */
 // Coupling<Args...>::Coupling(const std::string& name, Args&&... problems)
 template <class... Args>
 Coupling<Args...>::Coupling(const std::string& name, Args... problems)
-    : name_(name), problems_(std::make_tuple(std::forward<Args>(problems)...)) {}
+    : name_(name), problems_(std::make_tuple(std::forward<Args>(problems)...)) {
+  this->check_duplicate_problem_name();
+}
 
 /**
  * @brief Return the name of the coupling
  *
- * @tparam Args
+ * @tparam Args Types of the problems stored in the coupling.
  * @return const std::string
  */
 template <class... Args>
@@ -57,9 +60,93 @@ std::string Coupling<Args...>::get_name() {
 }
 
 /**
+ * @brief Set the name of the coupling
+ *
+ * @tparam Args Types of the problems stored in the coupling.
+ * @param std::string The name of the coupling
+ */
+template <class... Args>
+void Coupling<Args...>::set_name(const std::string& new_name) {
+  this->name_ = new_name;
+}
+
+/**
+ * @brief Checks for duplicate problem names and renames duplicates.
+ *
+ * @tparam Args Types of the problems stored in the coupling.
+ */
+template <class... Args>
+void Coupling<Args...>::check_duplicate_problem_name() {
+  std::set<std::string> problem_names;
+
+  std::apply(
+      [&](auto&... problem) {
+        (
+            [&] {
+              const std::string original_name = problem.get_name();
+              std::string new_name = original_name;
+
+              int suffix = 0;
+              while (problem_names.contains(new_name)) {
+                new_name = original_name + std::to_string(++suffix);
+              }
+
+              if (new_name != original_name) {
+                problem.set_name(new_name);
+              }
+
+              problem_names.insert(new_name);
+            }(),
+            ...);
+      },
+      problems_);
+}
+
+/**
+ * @brief Checks for duplicate post-processing directories and add prefix to avoid duplicates in CSV
+ * files.
+ *
+ * @tparam Args Types of the problems stored in the coupling.
+ */
+template <class... Args>
+void Coupling<Args...>::check_duplicate_post_processing_directory(std::size_t nb_couplings) {
+  std::map<std::string, int> directory_count;
+  std::apply(
+      [&](auto&... problem) {
+        (
+            [&] {
+              const std::string pb_dir = problem.get_problem_post_processing_directory();
+
+              if (!pb_dir.empty()) {
+                ++directory_count[pb_dir];
+              }
+            }(),
+            ...);
+      },
+      problems_);
+
+  std::apply(
+      [&](auto&... problem) {
+        (
+            [&] {
+              const std::string pb_dir = problem.get_problem_post_processing_directory();
+              if (!pb_dir.empty() && directory_count[pb_dir] > 1) {
+                std::string name = replaceSpaces(problem.get_name()) + "_time_specialized.csv";
+                if (nb_couplings > 1) {
+                  name = replaceSpaces(this->get_name()) + "_" + name;
+                }
+                problem.set_name_save_specialized(name);
+              }
+            }(),
+            ...);
+      },
+      problems_);
+}
+
+/**
  * @brief List all problems involved in the coupling
  *
- * @tparam Args
+ * @tparam Args Types of the problems stored in the coupling.
  */
 template <class... Args>
 void Coupling<Args...>::get_tree() {
@@ -71,7 +158,7 @@ void Coupling<Args...>::get_tree() {
 /**
  * @brief Initialize all the problems inside the coupling
  *
- * @tparam Args
+ * @tparam Args Types of the problems stored in the coupling.
  * @param initial_time
  */
 template <class... Args>
@@ -88,7 +175,7 @@ void Coupling<Args...>::initialize(const int& iter, const double& initial_time,
 /**
  * @brief Solve all the problems inside the coupling
  *
- * @tparam Args
+ * @tparam Args Types of the problems stored in the coupling.
  * @param iter
  * @param next_time
  * @param current_time
@@ -128,7 +215,7 @@ void Coupling<Args...>::execute(const int& iter, double& next_time, const double
 /**
  * @brief Update the variables of the problems inside this coupling
  *
- * @tparam Args
+ * @tparam Args Types of the problems stored in the coupling.
  */
 template <class... Args>
 void Coupling<Args...>::update() {
@@ -138,7 +225,7 @@ void Coupling<Args...>::update() {
 /**
  * @brief Save the variables of the problems inside this coupling
  *
- * @tparam Args
+ * @tparam Args Types of the problems stored in the coupling.
  * @param iter
  * @param current_time
  * @param current_time_step
@@ -153,7 +240,7 @@ void Coupling<Args...>::post_processing(const int& iter, const double& current_t
 /**
  * @brief Call the finalize methods of each problem
  *
- * @tparam Args
+ * @tparam Args Types of the problems stored in the coupling.
  */
 template <class... Args>
 void Coupling<Args...>::finalize() {
@@ -163,7 +250,7 @@ void Coupling<Args...>::finalize() {
 /**
  * @brief
  *
- * @tparam Args
+ * @tparam Args Types of the problems stored in the coupling.
  * @return std::vector<std::tuple<std::string, std::vector<std::tuple<std::string, bool, double>>>>
  */
 template <class... Args>
@@ -175,7 +262,7 @@ Coupling<Args...>::get_convergence() {
 /**
  * @brief Destroy the Coupling< Args...>:: Coupling object
  *
- * @tparam Args
+ * @tparam Args Types of the problems stored in the coupling.
  */
 template <class... Args>
 Coupling<Args...>::~Coupling() {}

--- a/kernel/include/PostProcessing/postprocessing.tpp
+++ b/kernel/include/PostProcessing/postprocessing.tpp
@@ -84,16 +84,21 @@ void PostProcessing<T, DC, DIM>::get_parameters() {
 
   this->level_of_detail_ =
       this->params_.template get_param_value_or_default<int>("level_of_detail", 1);
+
   this->enable_compute_energies_ =
       this->params_.template get_param_value_or_default<bool>("enable_compute_energies", true);
+
   this->enable_save_specialized_at_iter_ = this->params_.template get_param_value_or_default<bool>(
       "enable_save_specialized_at_iter", true);
+
   this->force_clean_output_dir_ =
       this->params_.template get_param_value_or_default<bool>("force_clean_output_dir", false);
+
   if (this->params_.has_parameter("iso_val_to_compute")) {
     this->iso_val_to_compute_ =
         this->params_.template get_param_value<MapStringDouble>("iso_val_to_compute");
   }
+
   if (this->params_.has_parameter("integral_to_compute")) {
     this->integral_to_compute_ =
         this->params_.template get_param_value<MapString2Double>("integral_to_compute");
@@ -104,6 +109,7 @@ void PostProcessing<T, DC, DIM>::get_parameters() {
       MFEM_VERIFY(upper_bound >= lower_bound, error_msg.c_str());
     }
   }
+
   std::string error_msg =
       "At least one the following parameter is expected: frequency, iterations_list, times_list";
   MFEM_VERIFY(this->params_.has_parameter("frequency") ||

--- a/kernel/include/Problems/Calphad_problem.hpp
+++ b/kernel/include/Problems/Calphad_problem.hpp
@@ -74,6 +74,7 @@ class Calphad_Problem : public ProblemBase<VAR, PST> {
   std::vector<std::string> sorted_KKS_phases_;
 
  public:
+  // With PST
   template <PbVar<VAR>... Args>
   Calphad_Problem(const Parameters& params, VAR& variables, const std::vector<Coefficients>& Coeff,
                   Convergence& convergence, PST& pst, Args&&... auxvariable);
@@ -104,6 +105,38 @@ class Calphad_Problem : public ProblemBase<VAR, PST> {
 
   template <PbVar<VAR>... Args>
   Calphad_Problem(const std::string& name, const Parameters& params, VAR& variables, PST& pst,
+                  Args&&... auxvariable);
+  // Without PST
+  template <PbVar<VAR>... Args>
+  Calphad_Problem(const Parameters& params, VAR& variables, const std::vector<Coefficients>& Coeff,
+                  Convergence& convergence, Args&&... auxvariable);
+
+  template <PbVar<VAR>... Args>
+  Calphad_Problem(const std::string& name, const Parameters& params, VAR& variables,
+                  const std::vector<Coefficients>& Coeff, Convergence& convergence,
+                  Args&&... auxvariable);
+
+  template <PbVar<VAR>... Args>
+  Calphad_Problem(const Parameters& params, VAR& variables, const std::vector<Coefficients>& Coeff,
+                  Args&&... auxvariable);
+
+  template <PbVar<VAR>... Args>
+  Calphad_Problem(const std::string& name, const Parameters& params, VAR& variables,
+                  const std::vector<Coefficients>& Coeff, Args&&... auxvariable);
+
+  template <PbVar<VAR>... Args>
+  Calphad_Problem(const Parameters& params, VAR& variables, Convergence& convergence,
+                  Args&&... auxvariable);
+
+  template <PbVar<VAR>... Args>
+  Calphad_Problem(const std::string& name, const Parameters& params, VAR& variables,
+                  Convergence& convergence, Args&&... auxvariable);
+
+  template <PbVar<VAR>... Args>
+  Calphad_Problem(const Parameters& params, VAR& variables, Args&&... auxvariable);
+
+  template <PbVar<VAR>... Args>
+  Calphad_Problem(const std::string& name, const Parameters& params, VAR& variables,
                   Args&&... auxvariable);
 
   /////////////////////////////////////////////////////

--- a/kernel/include/Problems/Calphad_problem.tpp
+++ b/kernel/include/Problems/Calphad_problem.tpp
@@ -74,6 +74,37 @@ Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem(const Parameters& params, VA
     this->check_molar_fractions();
   }
 }
+/**
+ * @brief Construct a new Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem object
+ *
+ * @tparam CALPHAD
+ * @tparam VAR
+ * @tparam PST
+ * @tparam Args
+ * @param params
+ * @param variables
+ * @param convergence
+ * @param auxvariables
+ */
+template <class CALPHAD, class VAR, class PST>
+template <PbVar<VAR>... Args>
+Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem(const Parameters& params, VAR& variables,
+                                                    const std::vector<Coefficients>& Coeff,
+                                                    Convergence& convergence,
+                                                    Args&&... auxvariables)
+    : ProblemBase<VAR, PST>("Calphad Problem", variables, Coeff, convergence, auxvariables...),
+      params_(params) {
+  // Mandatory to be placed before CALPHAD pointer creation
+  this->get_parameters();
+  this->check_variables_consistency();
+
+  this->CC_ = new CALPHAD(params, this->is_KKS_);
+  this->sorted_chemical_system_ = this->get_chemical_system();
+  if (this->is_KKS_) {
+    this->check_phasefield();
+    this->check_molar_fractions();
+  }
+}
 
 /**
  * @brief Construct a new Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem object
@@ -94,6 +125,34 @@ Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem(const Parameters& params, VA
                                                     PST& pst, Args&&... auxvariables)
     : ProblemBase<VAR, PST>("Calphad Problem", variables, Coeff, pst, auxvariables...),
       params_(params) {
+  // Mandatory to be placed before CALPHAD pointer creation
+  this->get_parameters();
+  this->check_variables_consistency();
+
+  this->CC_ = new CALPHAD(params, this->is_KKS_);
+  this->sorted_chemical_system_ = this->get_chemical_system();
+  if (this->is_KKS_) {
+    this->check_phasefield();
+    this->check_molar_fractions();
+  }
+}
+/**
+ * @brief Construct a new Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem object
+ *
+ * @tparam CALPHAD
+ * @tparam VAR
+ * @tparam PST
+ * @tparam Args
+ * @param params
+ * @param variables
+ * @param auxvariables
+ */
+template <class CALPHAD, class VAR, class PST>
+template <PbVar<VAR>... Args>
+Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem(const Parameters& params, VAR& variables,
+                                                    const std::vector<Coefficients>& Coeff,
+                                                    Args&&... auxvariables)
+    : ProblemBase<VAR, PST>("Calphad Problem", variables, Coeff, auxvariables...), params_(params) {
   // Mandatory to be placed before CALPHAD pointer creation
   this->get_parameters();
   this->check_variables_consistency();
@@ -139,6 +198,37 @@ Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem(const std::string& name,
     this->check_molar_fractions();
   }
 }
+/**
+ * @brief Construct a new Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem object
+ *
+ * @tparam CALPHAD
+ * @tparam VAR
+ * @tparam PST
+ * @tparam Args
+ * @param name
+ * @param params
+ * @param variables
+ * @param convergence
+ * @param auxvariables
+ */
+template <class CALPHAD, class VAR, class PST>
+template <PbVar<VAR>... Args>
+Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem(const std::string& name,
+                                                    const Parameters& params, VAR& variables,
+                                                    const std::vector<Coefficients>& Coeff,
+                                                    Convergence& convergence,
+                                                    Args&&... auxvariables)
+    : ProblemBase<VAR, PST>(name, variables, Coeff, convergence, auxvariables...), params_(params) {
+  // Mandatory to be placed before CALPHAD pointer creation
+  this->get_parameters();
+  this->check_variables_consistency();
+  this->CC_ = new CALPHAD(params, this->is_KKS_);
+  this->sorted_chemical_system_ = this->get_chemical_system();
+  if (this->is_KKS_) {
+    this->check_phasefield();
+    this->check_molar_fractions();
+  }
+}
 
 /**
  * @brief Construct a new Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem object
@@ -160,6 +250,35 @@ Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem(const std::string& name,
                                                     const std::vector<Coefficients>& Coeff,
                                                     PST& pst, Args&&... auxvariables)
     : ProblemBase<VAR, PST>(name, variables, Coeff, pst, auxvariables...), params_(params) {
+  // Mandatory to be placed before CALPHAD pointer creation
+  this->get_parameters();
+  this->check_variables_consistency();
+  this->CC_ = new CALPHAD(params, this->is_KKS_);
+  this->sorted_chemical_system_ = this->get_chemical_system();
+  if (this->is_KKS_) {
+    this->check_phasefield();
+    this->check_molar_fractions();
+  }
+}
+/**
+ * @brief Construct a new Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem object
+ *
+ * @tparam CALPHAD
+ * @tparam VAR
+ * @tparam PST
+ * @tparam Args
+ * @param name
+ * @param params
+ * @param variables
+ * @param auxvariables
+ */
+template <class CALPHAD, class VAR, class PST>
+template <PbVar<VAR>... Args>
+Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem(const std::string& name,
+                                                    const Parameters& params, VAR& variables,
+                                                    const std::vector<Coefficients>& Coeff,
+                                                    Args&&... auxvariables)
+    : ProblemBase<VAR, PST>(name, variables, Coeff, auxvariables...), params_(params) {
   // Mandatory to be placed before CALPHAD pointer creation
   this->get_parameters();
   this->check_variables_consistency();
@@ -202,6 +321,36 @@ Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem(const Parameters& params, VA
     this->check_molar_fractions();
   }
 }
+/**
+ * @brief Construct a new Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem object
+ *
+ * @tparam CALPHAD
+ * @tparam VAR
+ * @tparam PST
+ * @tparam Args
+ * @param params
+ * @param variables
+ * @param convergence
+ * @param auxvariables
+ */
+template <class CALPHAD, class VAR, class PST>
+template <PbVar<VAR>... Args>
+Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem(const Parameters& params, VAR& variables,
+                                                    Convergence& convergence,
+                                                    Args&&... auxvariables)
+    : ProblemBase<VAR, PST>("Calphad Problem", variables, convergence, auxvariables...),
+      params_(params) {
+  // Mandatory to be placed before CALPHAD pointer creation
+  this->get_parameters();
+  this->check_variables_consistency();
+
+  this->CC_ = new CALPHAD(params, this->is_KKS_);
+  this->sorted_chemical_system_ = this->get_chemical_system();
+  if (this->is_KKS_) {
+    this->check_phasefield();
+    this->check_molar_fractions();
+  }
+}
 
 /**
  * @brief Construct a new Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem object
@@ -220,6 +369,33 @@ template <PbVar<VAR>... Args>
 Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem(const Parameters& params, VAR& variables,
                                                     PST& pst, Args&&... auxvariables)
     : ProblemBase<VAR, PST>("Calphad Problem", variables, pst, auxvariables...), params_(params) {
+  // Mandatory to be placed before CALPHAD pointer creation
+  this->get_parameters();
+  this->check_variables_consistency();
+
+  this->CC_ = new CALPHAD(params, this->is_KKS_);
+  this->sorted_chemical_system_ = this->get_chemical_system();
+  if (this->is_KKS_) {
+    this->check_phasefield();
+    this->check_molar_fractions();
+  }
+}
+/**
+ * @brief Construct a new Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem object
+ *
+ * @tparam CALPHAD
+ * @tparam VAR
+ * @tparam PST
+ * @tparam Args
+ * @param params
+ * @param variables
+ * @param auxvariables
+ */
+template <class CALPHAD, class VAR, class PST>
+template <PbVar<VAR>... Args>
+Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem(const Parameters& params, VAR& variables,
+                                                    Args&&... auxvariables)
+    : ProblemBase<VAR, PST>("Calphad Problem", variables, auxvariables...), params_(params) {
   // Mandatory to be placed before CALPHAD pointer creation
   this->get_parameters();
   this->check_variables_consistency();
@@ -263,6 +439,36 @@ Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem(const std::string& name,
     this->check_molar_fractions();
   }
 }
+/**
+ * @brief Construct a new Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem object
+ *
+ * @tparam CALPHAD
+ * @tparam VAR
+ * @tparam PST
+ * @tparam Args
+ * @param name
+ * @param params
+ * @param variables
+ * @param convergence
+ * @param auxvariables
+ */
+template <class CALPHAD, class VAR, class PST>
+template <PbVar<VAR>... Args>
+Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem(const std::string& name,
+                                                    const Parameters& params, VAR& variables,
+                                                    Convergence& convergence,
+                                                    Args&&... auxvariables)
+    : ProblemBase<VAR, PST>(name, variables, convergence, auxvariables...), params_(params) {
+  // Mandatory to be placed before CALPHAD pointer creation
+  this->get_parameters();
+  this->check_variables_consistency();
+  this->CC_ = new CALPHAD(params, this->is_KKS_);
+  this->sorted_chemical_system_ = this->get_chemical_system();
+  if (this->is_KKS_) {
+    this->check_phasefield();
+    this->check_molar_fractions();
+  }
+}
 
 /**
  * @brief Construct a new Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem object
@@ -283,6 +489,34 @@ Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem(const std::string& name,
                                                     const Parameters& params, VAR& variables,
                                                     PST& pst, Args&&... auxvariables)
     : ProblemBase<VAR, PST>(name, variables, pst, auxvariables...), params_(params) {
+  // Mandatory to be placed before CALPHAD pointer creation
+  this->get_parameters();
+  this->check_variables_consistency();
+  this->CC_ = new CALPHAD(params, this->is_KKS_);
+  this->sorted_chemical_system_ = this->get_chemical_system();
+  if (this->is_KKS_) {
+    this->check_phasefield();
+    this->check_molar_fractions();
+  }
+}
+/**
+ * @brief Construct a new Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem object
+ *
+ * @tparam CALPHAD
+ * @tparam VAR
+ * @tparam PST
+ * @tparam Args
+ * @param name
+ * @param params
+ * @param variables
+ * @param auxvariables
+ */
+template <class CALPHAD, class VAR, class PST>
+template <PbVar<VAR>... Args>
+Calphad_Problem<CALPHAD, VAR, PST>::Calphad_Problem(const std::string& name,
+                                                    const Parameters& params, VAR& variables,
+                                                    Args&&... auxvariables)
+    : ProblemBase<VAR, PST>(name, variables, auxvariables...), params_(params) {
   // Mandatory to be placed before CALPHAD pointer creation
   this->get_parameters();
   this->check_variables_consistency();
@@ -542,12 +776,12 @@ template <class CALPHAD, class VAR, class PST>
 void Calphad_Problem<CALPHAD, VAR, PST>::finalize() {
   this->CC_->finalize();
   int rank = mfem::Mpi::WorldRank();
-  if (rank == 0) {
-    if (!this->pst_.get_enable_save_specialized_at_iter()) {
+  if (rank == 0 && this->has_pst()) {
+    if (!this->get_pst().get_enable_save_specialized_at_iter()) {
       auto time_spe_mmap = this->CC_->get_time_specialized();
       if (!time_spe_mmap.empty()) {
         std::string str = "calphad.csv";
-        this->pst_.save_specialized(time_spe_mmap, str);
+        this->get_pst().save_specialized(time_spe_mmap, str);
       }
     }
   }
@@ -566,18 +800,20 @@ void Calphad_Problem<CALPHAD, VAR, PST>::finalize() {
 template <class CALPHAD, class VAR, class PST>
 void Calphad_Problem<CALPHAD, VAR, PST>::post_processing(const int& iter,
                                                          const double& current_time) {
-  int rank = mfem::Mpi::WorldRank();
-  if (rank == 0) {
-    if (this->pst_.get_enable_save_specialized_at_iter()) {
-      auto time_spe_mmap = this->CC_->get_time_specialized();
-      if (!time_spe_mmap.empty()) {
-        std::string str = "calphad.csv";
-        this->pst_.save_specialized(time_spe_mmap, str);
+  if (this->has_pst()) {
+    int rank = mfem::Mpi::WorldRank();
+    if (rank == 0) {
+      if (this->get_pst().get_enable_save_specialized_at_iter()) {
+        auto time_spe_mmap = this->CC_->get_time_specialized();
+        if (!time_spe_mmap.empty()) {
+          std::string str = "calphad.csv";
+          this->get_pst().save_specialized(time_spe_mmap, str);
+        }
       }
     }
-  }
-  if (this->pst_.get_enable_save_specialized_at_iter()) {
-    this->CC_->clear_time_specialized();
+    if (this->get_pst().get_enable_save_specialized_at_iter()) {
+      this->CC_->clear_time_specialized();
+    }
   }
   // Save for visualization
   ProblemBase<VAR, PST>::post_processing(iter, current_time);
@@ -701,7 +937,10 @@ std::vector<mfem::Vector> Calphad_Problem<CALPHAD, VAR, PST>::get_tp_conditions(
         MFEM_VERIFY(variable_info.size() == 2,
                     " Calphad_Problem<CALPHAD, VAR, PST>::get_tp_conditions() : expected "
                     "[component, 'x'] or [component, 'N']");
-        const int id = this->findIndexOfTuple(this->sorted_chemical_system_, variable_info[0]);
+        const int id =
+            this->findIndexOfTuple(this->sorted_chemical_system_, toUpperCase(variable_info[0]));
+        MFEM_VERIFY(id >= 0,
+                    "Element '" + variable_info[0] + "' not found in the chemical system.");
 
         aux_gf[id + 2] = gf;
       }
@@ -744,6 +983,8 @@ std::vector<mfem::Vector> Calphad_Problem<CALPHAD, VAR, PST>::get_old_tp_conditi
         const int id =
             this->findIndexOfTuple(this->sorted_chemical_system_, toUpperCase(variable_info[0]));
 
+        MFEM_VERIFY(id >= 0,
+                    "Element '" + variable_info[0] + "' not found in the chemical system.");
         aux_gf[id + 2] = gf;
       }
     }
@@ -838,7 +1079,8 @@ void Calphad_Problem<CALPHAD, VAR, PST>::check_molar_fractions() {
         (calphad_outputs::from(symbol) == calphad_outputs::xp)) {
       auto variable_info = var.get_additional_variable_info();
 
-      const int id = this->findIndexOfTuple(this->sorted_chemical_system_, variable_info[0]);
+      const int id =
+          this->findIndexOfTuple(this->sorted_chemical_system_, toUpperCase(variable_info[0]));
       if (id > -1) check_counter++;
     }
   }

--- a/kernel/include/Problems/Problem.hpp
+++ b/kernel/include/Problems/Problem.hpp
@@ -63,6 +63,7 @@ class Problem : public ProblemBase<VAR, PST> {
   void set_time_coefficients(double time) override;
 
  public:
+  // With PST
   template <PbVar<VAR>... Args>
   Problem(const OPE& oper, VAR& variables, const std::vector<Coefficients>& Coeff,
           Convergence& convergence, PST& pst, Args&&... auxvariable);
@@ -79,6 +80,23 @@ class Problem : public ProblemBase<VAR, PST> {
   template <PbVar<VAR>... Args>
   Problem(const std::string& name, const OPE& oper, VAR& variables,
           const std::vector<Coefficients>& Coeff, PST& pst, Args&&... auxvariable);
+
+  // Without PST
+  template <PbVar<VAR>... Args>
+  Problem(const OPE& oper, VAR& variables, const std::vector<Coefficients>& Coeff,
+          Convergence& convergence, Args&&... auxvariable);
+
+  template <PbVar<VAR>... Args>
+  Problem(const OPE& oper, VAR& variables, const std::vector<Coefficients>& Coeff,
+          Args&&... auxvariable);
+
+  template <PbVar<VAR>... Args>
+  Problem(const std::string& name, const OPE& oper, VAR& variables,
+          const std::vector<Coefficients>& Coeff, Convergence& convergence, Args&&... auxvariable);
+
+  template <PbVar<VAR>... Args>
+  Problem(const std::string& name, const OPE& oper, VAR& variables,
+          const std::vector<Coefficients>& Coeff, Args&&... auxvariable);
 
   /////////////////////////////////////////////////////
   void initialize(const double& initial_time, const double time_step) override;

--- a/kernel/include/Problems/Problem.tpp
+++ b/kernel/include/Problems/Problem.tpp
@@ -87,7 +87,55 @@ Problem<OPE, VAR, PST>::Problem(const OPE& oper, VAR& variables,
   MFEM_VERIFY(variables.get_variables_number() == Coeff.size(),
               "Error: the number of Coefficients objects must be equal to the number of primary "
               "variables. Please check your data.");
-  this->oper_.set_coefficients(Coeff, this->pst_.get_enable_compute_energies());
+  if (this->has_pst()) {
+    this->oper_.set_coefficients(Coeff, this->get_pst().get_enable_compute_energies());
+  }
+}
+
+/**
+ * @brief Construct a PDE Problem object.
+ *
+ * Initializes a PDE problem by binding the operator, primary variables,
+ * auxiliary variables, coefficients, convergence criteria, and post-processing. The operator is
+ * configured with the provided coefficients and energy-computation settings from the problem state.
+ *
+ * @tparam OPE
+ *   Operator type defining the nonlinear PDE.
+ * @tparam VAR
+ *   Primary variable container type.
+ * @tparam PST
+ *   PostProcessing.
+ * @tparam Args
+ *   Types of auxiliary variables satisfying the `PbVar<VAR>` constraint.
+ *
+ * @param oper
+ *   Nonlinear operator associated with the problem.
+ * @param variables
+ *   Primary problem variables.
+ * @param Coeff
+ *   Collection of coefficients used by the operator.
+ * @param convergence
+ *   Convergence criteria.
+ * @param auxvariables
+ *   Optional auxiliary variables forwarded to the base problem.
+ *
+ * @pre
+ * - `oper` must be fully constructed.
+ * - `Coeff` must be compatible with the operator.
+ *
+ */
+template <class OPE, class VAR, class PST>
+template <PbVar<VAR>... Args>
+Problem<OPE, VAR, PST>::Problem(const OPE& oper, VAR& variables,
+                                const std::vector<Coefficients>& Coeff, Convergence& convergence,
+                                Args&&... auxvariables)
+    : ProblemBase<VAR, PST>("Default NonLinear problem", variables, Coeff, convergence,
+                            auxvariables...),
+      oper_(oper) {
+  MFEM_VERIFY(variables.get_variables_number() == Coeff.size(),
+              "Error: the number of Coefficients objects must be equal to the number of primary "
+              "variables. Please check your data.");
+  this->oper_.set_coefficients(Coeff, false);
 }
 
 /**
@@ -132,7 +180,52 @@ Problem<OPE, VAR, PST>::Problem(const OPE& oper, VAR& variables,
   MFEM_VERIFY(variables.get_variables_number() == Coeff.size(),
               "Error: the number of Coefficients objects must be equal to the number of primary "
               "variables. Please check your data.");
-  this->oper_.set_coefficients(Coeff, this->pst_.get_enable_compute_energies());
+  if (this->has_pst()) {
+    this->oper_.set_coefficients(Coeff, this->get_pst().get_enable_compute_energies());
+  }
+}
+
+/**
+ * @brief Construct a PDE Problem object.
+ *
+ * Initializes a PDE problem by binding the operator, primary variables,
+ * auxiliary variables, coefficients,  and post-processing. The operator is
+ * configured with the provided coefficients and energy-computation settings from the problem state.
+ *
+ * @tparam OPE
+ *   Operator type defining the nonlinear PDE.
+ * @tparam VAR
+ *   Primary variable container type.
+ * @tparam PST
+ *   PostProcessing.
+ * @tparam Args
+ *   Types of auxiliary variables satisfying the `PbVar<VAR>` constraint.
+ *
+ * @param oper
+ *   Nonlinear operator associated with the problem.
+ * @param variables
+ *   Primary problem variables.
+ * @param Coeff
+ *   Collection of coefficients used by the operator.
+
+ * @param auxvariables
+ *   Optional auxiliary variables forwarded to the base problem.
+ *
+ * @pre
+ * - `oper` must be fully constructed.
+ * - `Coeff` must be compatible with the operator.
+ *
+ */
+template <class OPE, class VAR, class PST>
+template <PbVar<VAR>... Args>
+Problem<OPE, VAR, PST>::Problem(const OPE& oper, VAR& variables,
+                                const std::vector<Coefficients>& Coeff, Args&&... auxvariables)
+    : ProblemBase<VAR, PST>("Default NonLinear problem", variables, Coeff, auxvariables...),
+      oper_(oper) {
+  MFEM_VERIFY(variables.get_variables_number() == Coeff.size(),
+              "Error: the number of Coefficients objects must be equal to the number of primary "
+              "variables. Please check your data.");
+  this->oper_.set_coefficients(Coeff, false);
 }
 
 /**
@@ -181,7 +274,55 @@ Problem<OPE, VAR, PST>::Problem(const std::string& name, const OPE& oper, VAR& v
   MFEM_VERIFY(variables.get_variables_number() == Coeff.size(),
               "Error: the number of Coefficients objects must be equal to the number of primary "
               "variables. Please check your data.");
-  this->oper_.set_coefficients(Coeff, this->pst_.get_enable_compute_energies());
+  if (this->has_pst()) {
+    this->oper_.set_coefficients(Coeff, this->get_pst().get_enable_compute_energies());
+  }
+}
+
+/**
+ * @brief Construct a PDE Problem object.
+ *
+ * Initializes a PDE problem by binding the name, operator, primary variables,
+ * auxiliary variables, coefficients,  convergence criteria, and post-processing. The operator is
+ * configured with the provided coefficients and energy-computation settings from the problem state.
+ *
+ * @tparam OPE
+ *   Operator type defining the nonlinear PDE.
+ * @tparam VAR
+ *   Primary variable container type.
+ * @tparam PST
+ *   PostProcessing.
+ * @tparam Args
+ *   Types of auxiliary variables satisfying the `PbVar<VAR>` constraint.
+ *
+ * @param name
+ *   Name of the problem.
+ * @param oper
+ *   Nonlinear operator associated with the problem.
+ * @param variables
+ *   Primary problem variables.
+ * @param Coeff
+ *   Collection of coefficients used by the operator.
+ * @param convergence
+ *   Convergence criteria.
+ * @param auxvariables
+ *   Optional auxiliary variables forwarded to the base problem.
+ *
+ * @pre
+ * - `oper` must be fully constructed.
+ * - `Coeff` must be compatible with the operator.
+ *
+ */
+template <class OPE, class VAR, class PST>
+template <PbVar<VAR>... Args>
+Problem<OPE, VAR, PST>::Problem(const std::string& name, const OPE& oper, VAR& variables,
+                                const std::vector<Coefficients>& Coeff, Convergence& convergence,
+                                Args&&... auxvariables)
+    : ProblemBase<VAR, PST>(name, variables, Coeff, convergence, auxvariables...), oper_(oper) {
+  MFEM_VERIFY(variables.get_variables_number() == Coeff.size(),
+              "Error: the number of Coefficients objects must be equal to the number of primary "
+              "variables. Please check your data.");
+  this->oper_.set_coefficients(Coeff, false);
 }
 
 /**
@@ -227,11 +368,17 @@ Problem<OPE, VAR, PST>::Problem(const std::string& name, const OPE& oper, VAR& v
   MFEM_VERIFY(variables.get_variables_number() == Coeff.size(),
               "Error: the number of Coefficients objects must be equal to the number of primary "
               "variables. Please check your data.");
-  this->oper_.set_coefficients(Coeff, this->pst_.get_enable_compute_energies());
+  if (this->has_pst()) {
+    this->oper_.set_coefficients(Coeff, this->get_pst().get_enable_compute_energies());
+  }
 }
 
 /**
- * @brief Initialize the Problem
+ * @brief Construct a PDE Problem object.
+ *
+ * Initializes a PDE problem by binding the name, operator, primary variables,
+ * auxiliary variables, coefficients,  and post-processing. The operator is
+ * configured with the provided coefficients and energy-computation settings from the problem state.
  *
  * @tparam OPE
  *   Operator type defining the nonlinear PDE.
@@ -239,10 +386,53 @@ Problem<OPE, VAR, PST>::Problem(const std::string& name, const OPE& oper, VAR& v
  *   Primary variable container type.
  * @tparam PST
  *   PostProcessing.
+ * @tparam Args
+ *   Types of auxiliary variables satisfying the `PbVar<VAR>` constraint.
+ *
+ * @param name
+ *   Name of the problem.
+ * @param oper
+ *   Nonlinear operator associated with the problem.
+ * @param variables
+ *   Primary problem variables.
+ * @param Coeff
+ *   Collection of coefficients used by the operator.
+ * @param auxvariables
+ *   Optional auxiliary variables forwarded to the base problem.
+ *
+ * @pre
+ * - `oper` must be fully constructed.
+ * - `Coeff` must be compatible with the operator.
+ *
+ */
+template <class OPE, class VAR, class PST>
+template <PbVar<VAR>... Args>
+Problem<OPE, VAR, PST>::Problem(const std::string& name, const OPE& oper, VAR& variables,
+                                const std::vector<Coefficients>& Coeff, Args&&... auxvariables)
+    : ProblemBase<VAR, PST>(name, variables, Coeff, auxvariables...), oper_(oper) {
+  MFEM_VERIFY(variables.get_variables_number() == Coeff.size(),
+              "Error: the number of Coefficients objects must be equal to the number of primary "
+              "variables. Please check your data.");
+  this->oper_.set_coefficients(Coeff, false);
+}
+
+/**
+ * @brief Initializes the problem.
+ *
+ * Initializes the base problem, the nonlinear operator, and performs
+ * the initial adaptive mesh refinement when AMR is enabled.
+ *
+ * @tparam OPE
+ *   Nonlinear operator type associated with the problem.
+ * @tparam VAR
+ *   Primary problem variables type.
+ * @tparam PST
+ *   Post-processing type.
+ *
  * @param initial_time
- *   Initial time
+ *   Initial simulation time.
  * @param time_step
- *   current time_step
+ *   Current simulation time step.
  */
 template <class OPE, class VAR, class PST>
 void Problem<OPE, VAR, PST>::initialize(const double& initial_time, const double time_step) {
@@ -285,8 +475,10 @@ void Problem<OPE, VAR, PST>::save(const int iter, const double& current_time) {
 template <class OPE, class VAR, class PST>
 void Problem<OPE, VAR, PST>::finalize() {
   // Save specialized values only at the end of calculation if required
-  bool must_be_saved = !this->pst_.get_enable_save_specialized_at_iter();
-  this->save_specialized(must_be_saved);
+  if (this->has_pst()) {
+    bool must_be_saved = !this->get_pst().get_enable_save_specialized_at_iter();
+    this->save_specialized(must_be_saved);
+  }
 }
 
 /**
@@ -308,14 +500,15 @@ void Problem<OPE, VAR, PST>::save_specialized(bool must_be_saved) {
   if (rank == 0) {
     if (must_be_saved) {
       if (!this->oper_.get_time_specialized().empty()) {
-        this->pst_.save_specialized(this->oper_.get_time_specialized());
+        this->get_pst().save_specialized(this->oper_.get_time_specialized(),
+                                         this->name_save_specialized_);
       }
 
       if (!this->oper_.get_time_iso_specialized().empty()) {
         for (const auto& [var_name, variable_time_iso_specialized] :
              this->oper_.get_time_iso_specialized()) {
           std::string str = var_name + "_iso_computation.csv";
-          this->pst_.save_specialized(variable_time_iso_specialized, str);
+          this->get_pst().save_specialized(variable_time_iso_specialized, str);
         }
       }
     }
@@ -341,55 +534,59 @@ void Problem<OPE, VAR, PST>::save_specialized(bool must_be_saved) {
  */
 template <class OPE, class VAR, class PST>
 void Problem<OPE, VAR, PST>::post_processing(const int& iter, const double& current_time) {
-  const auto nvars = this->variables_.get_variables_number();
-  std::vector<mfem::Vector> u_vect;
-  const double current_time_step = this->oper_.get_current_time_step();
+  if (this->has_pst()) {
+    const auto nvars = this->variables_.get_variables_number();
+    std::vector<mfem::Vector> u_vect;
+    const double current_time_step = this->oper_.get_current_time_step();
 
-  // Isovalue to compute by variable
-  const std::map<std::string, double> map_iso_value = this->pst_.get_iso_val_to_compute();
+    // Isovalue to compute by variable
+    const std::map<std::string, double> map_iso_value = this->get_pst().get_iso_val_to_compute();
 
-  // Integral value to compute by variable
-  const std::map<std::string, std::tuple<double, double>> map_integral =
-      this->pst_.get_integral_to_compute();
+    // Integral value to compute by variable
+    const std::map<std::string, std::tuple<double, double>> map_integral =
+        this->get_pst().get_integral_to_compute();
 
-  for (unsigned int iv = 0; iv < nvars; iv++) {
-    auto vv = this->variables_[iv];
-    auto solution = vv.get_analytical_solution();
-    auto unk = vv.get_unknown();
-    auto unk_name = vv.getVariableName();
+    for (unsigned int iv = 0; iv < nvars; iv++) {
+      auto vv = this->variables_[iv];
+      auto solution = vv.get_analytical_solution();
+      auto unk = vv.get_unknown();
+      auto unk_name = vv.getVariableName();
 
-    // Errors
-    if (solution != nullptr) {
-      auto solution_func = solution.get();
-      this->oper_.ComputeError(iter, current_time, current_time_step, iv, unk_name, unk,
-                               *solution_func);
+      // Errors
+      if (solution != nullptr) {
+        auto solution_func = solution.get();
+        this->oper_.ComputeError(iter, current_time, current_time_step, iv, unk_name, unk,
+                                 *solution_func);
+      }
+
+      // Isovalues
+      if (!map_iso_value.empty() && map_iso_value.contains(unk_name)) {
+        const double iso_value = map_iso_value.at(unk_name);
+        this->oper_.ComputeIsoVal(iter, current_time, current_time_step, iv, unk_name, unk,
+                                  iso_value);
+      }
+
+      // Integral
+      if (!map_integral.empty() && map_integral.contains(unk_name)) {
+        const auto& [lower_bound, upper_bound] = map_integral.at(unk_name);
+        this->oper_.ComputeIntegral(iter, current_time, current_time_step, iv, unk_name, unk,
+                                    lower_bound, upper_bound);
+      }
+      u_vect.emplace_back(std::move(unk));
     }
-
-    // Isovalues
-    if (!map_iso_value.empty() && map_iso_value.contains(unk_name)) {
-      const double iso_value = map_iso_value.at(unk_name);
-      this->oper_.ComputeIsoVal(iter, current_time, current_time_step, iv, unk_name, unk,
-                                iso_value);
+    // Compute Energies is required (True by default)
+    if (this->get_pst().get_enable_compute_energies()) {
+      this->oper_.ComputeEnergies(iter, current_time, current_time_step, u_vect);
     }
-
-    // Integral
-    if (!map_integral.empty() && map_integral.contains(unk_name)) {
-      const auto& [lower_bound, upper_bound] = map_integral.at(unk_name);
-      this->oper_.ComputeIntegral(iter, current_time, current_time_step, iv, unk_name, unk,
-                                  lower_bound, upper_bound);
-    }
-    u_vect.emplace_back(std::move(unk));
-  }
-  // Compute Energies is required (True by default)
-  if (this->pst_.get_enable_compute_energies()) {
-    this->oper_.ComputeEnergies(iter, current_time, current_time_step, u_vect);
   }
   // Save variables for visualization
   ProblemBase<VAR, PST>::post_processing(iter, current_time);
 
   // Save specialized values at each time-step if required
-  bool must_be_saved = this->pst_.get_enable_save_specialized_at_iter();
-  this->save_specialized(must_be_saved);
+  if (this->has_pst()) {
+    bool must_be_saved = this->get_pst().get_enable_save_specialized_at_iter();
+    this->save_specialized(must_be_saved);
+  }
 }
 
 /**

--- a/kernel/include/Problems/ProblemBase.hpp
+++ b/kernel/include/Problems/ProblemBase.hpp
@@ -62,18 +62,28 @@ concept PbVar = std::same_as<std::remove_cvref_t<T>, VAR>;
  */
 template <class VAR, class PST>
 class ProblemBase {
+  static_assert(!std::same_as<VAR, PST>,
+                "ProblemBase: VAR and PST must not be the same type, "
+                "otherwise overload resolution becomes ambiguous between "
+                "the constructors with/without PST (PbVar<T,VAR> would "
+                "also match PST&).");
+
  private:
   void check_convergence(const std::vector<std::unique_ptr<mfem::Vector>>& unks);
 
  protected:
   Geometry geometry_ = Geometry::Cartesian;
   std::string name_{"Unnamed problem"};
+  std::string name_save_specialized_{"time_specialized.csv"};
   VAR& variables_;
   std::vector<VAR*> auxvariables_;
 
   std::vector<Coefficients> coefficients_;
 
-  PST& pst_;
+  std::optional<std::reference_wrapper<PST>> pst_;
+
+  std::string problem_post_processing_directory_;
+
   std::vector<mfem::Vector> unknown_;
   std::shared_ptr<Convergence> convergence_;
   std::vector<std::tuple<std::string, bool, double>> var_convergence_;
@@ -83,7 +93,7 @@ class ProblemBase {
  public:
   void set_amr(AMRBase<VAR>* amr) { this->amr_ = amr; }
 
- public:
+  // With PST object
   template <PbVar<VAR>... Args>
   ProblemBase(const std::string& name, VAR& variables, const std::vector<Coefficients>& Coeff,
               PST& pst, Args&&... auxvariables);
@@ -99,10 +109,42 @@ class ProblemBase {
   ProblemBase(const std::string& name, VAR& variables, Convergence& convergence, PST& pst,
               Args&&... auxvariables);
 
+  // Without PST object
+
+  template <PbVar<VAR>... Args>
+  ProblemBase(const std::string& name, VAR& variables, const std::vector<Coefficients>& Coeff,
+              Args&&... auxvariables);
+
+  template <PbVar<VAR>... Args>
+  ProblemBase(const std::string& name, VAR& variables, const std::vector<Coefficients>& Coeff,
+              Convergence& convergence, Args&&... auxvariables);
+
+  template <PbVar<VAR>... Args>
+  ProblemBase(const std::string& name, VAR& variables, Args&&... auxvariables);
+
+  template <PbVar<VAR>... Args>
+  ProblemBase(const std::string& name, VAR& variables, Convergence& convergence,
+              Args&&... auxvariables);
+  //
+
+  bool has_pst() const noexcept { return pst_.has_value(); }
+
+  PST& get_pst() {
+    MFEM_VERIFY(pst_.has_value(), "PST not defined for this Problem");
+    return pst_->get();
+  }
+
+  //
+
   virtual ~ProblemBase() = default;
 
   std::string get_name();
+  void set_name(const std::string& new_name);
+
   VAR get_problem_variables();
+
+  std::string get_problem_post_processing_directory();
+  void set_name_save_specialized(const std::string& new_name);
 
   std::vector<std::tuple<std::string, bool, double>> get_convergence();
 

--- a/kernel/include/Problems/ProblemBase.tpp
+++ b/kernel/include/Problems/ProblemBase.tpp
@@ -41,6 +41,7 @@
 #include "Options/ProblemsOptions.hpp"
 #include "Parameters/Parameter.hpp"
 #include "PostProcessing/postprocessing.hpp"
+#include "Utils/UtilsForData.hpp"
 #include "Variables/Variable.hpp"
 #include "mfem.hpp"  // NOLINT [no include the directory when naming mfem include file]
 
@@ -64,6 +65,36 @@ ProblemBase<VAR, PST>::ProblemBase(const std::string& name, VAR& variables,
                                    const std::vector<Coefficients>& Coeff, Convergence& convergence,
                                    PST& pst, Args&&... auxvariables)
     : name_(name), variables_(variables), coefficients_(Coeff), pst_(pst) {
+  this->convergence_ = std::make_shared<Convergence>(convergence);
+  if constexpr (sizeof...(auxvariables) == 0) {
+    this->auxvariables_.clear();
+  } else {
+    this->auxvariables_ = {&auxvariables...};
+  }
+
+  if (this->has_pst()) {
+    this->problem_post_processing_directory_ = this->get_pst().get_post_processing_directory();
+  }
+}
+/**
+ * @brief Constructs a new ProblemBase object.
+ *
+ * @tparam VAR Type representing the Variables.
+ * @tparam PST Type representing the PostProcessing.
+ * @tparam Args Types of auxiliary variables passed variadically.
+ *
+ * @param name Name of the problem.
+ * @param variables Reference to the Variables object.
+ * @param convergence Reference to the Convergence  object.
+ * @param auxvariables Variadic pack of auxiliary variables.
+ * @param Coeff Vector of coefficients.
+ */
+template <class VAR, class PST>
+template <PbVar<VAR>... Args>
+ProblemBase<VAR, PST>::ProblemBase(const std::string& name, VAR& variables,
+                                   const std::vector<Coefficients>& Coeff, Convergence& convergence,
+                                   Args&&... auxvariables)
+    : name_(name), variables_(variables), coefficients_(Coeff), pst_(std::nullopt) {
   this->convergence_ = std::make_shared<Convergence>(convergence);
   if constexpr (sizeof...(auxvariables) == 0) {
     this->auxvariables_.clear();
@@ -97,6 +128,38 @@ ProblemBase<VAR, PST>::ProblemBase(const std::string& name, VAR& variables,
   } else {
     this->auxvariables_ = {&auxvariables...};
   }
+
+  if (this->has_pst()) {
+    this->problem_post_processing_directory_ = this->get_pst().get_post_processing_directory();
+  }
+}
+/**
+ * @brief Constructs a new ProblemBase object.
+ *
+ * @tparam VAR Type representing the Variables.
+ * @tparam PST Type representing the PostProcessing.
+ * @tparam Args Types of auxiliary variables passed variadically.
+ * @tparam CArgs Types of coefficients passed variadically.
+ *
+ * @param name Name of the problem.
+ * @param variables Reference to the Variables object.
+ * @param auxvariables Variadic pack of auxiliary variables.
+ * @param Coeff Variadic pack of coefficients.
+ */
+template <class VAR, class PST>
+template <PbVar<VAR>... Args>
+ProblemBase<VAR, PST>::ProblemBase(const std::string& name, VAR& variables,
+                                   const std::vector<Coefficients>& Coeff, Args&&... auxvariables)
+    : name_(name),
+      variables_(variables),
+      coefficients_(Coeff),
+      pst_(std::nullopt),
+      convergence_(nullptr) {
+  if constexpr (sizeof...(auxvariables) == 0) {
+    this->auxvariables_.clear();
+  } else {
+    this->auxvariables_ = {&auxvariables...};
+  }
 }
 
 /**
@@ -111,13 +174,39 @@ ProblemBase<VAR, PST>::ProblemBase(const std::string& name, VAR& variables,
  * @param pst Reference to the PostProcessing object.
  * @param convergence Reference to the Convergence  object.
  * @param auxvariables Variadic pack of auxiliary variables.
- * @param Coeff Vector of coefficients.
  */
 template <class VAR, class PST>
 template <PbVar<VAR>... Args>
 ProblemBase<VAR, PST>::ProblemBase(const std::string& name, VAR& variables,
                                    Convergence& convergence, PST& pst, Args&&... auxvariables)
     : name_(name), variables_(variables), pst_(pst) {
+  this->convergence_ = std::make_shared<Convergence>(convergence);
+  if constexpr (sizeof...(auxvariables) == 0) {
+    this->auxvariables_.clear();
+  } else {
+    this->auxvariables_ = {&auxvariables...};
+  }
+  if (this->has_pst()) {
+    this->problem_post_processing_directory_ = this->get_pst().get_post_processing_directory();
+  }
+}
+/**
+ * @brief Constructs a new ProblemBase object.
+ *
+ * @tparam VAR Type representing the Variables.
+ * @tparam PST Type representing the PostProcessing.
+ * @tparam Args Types of auxiliary variables passed variadically.
+ *
+ * @param name Name of the problem.
+ * @param variables Reference to the Variables object.
+ * @param convergence Reference to the Convergence  object.
+ * @param auxvariables Variadic pack of auxiliary variables.
+ */
+template <class VAR, class PST>
+template <PbVar<VAR>... Args>
+ProblemBase<VAR, PST>::ProblemBase(const std::string& name, VAR& variables,
+                                   Convergence& convergence, Args&&... auxvariables)
+    : name_(name), variables_(variables), pst_(std::nullopt) {
   this->convergence_ = std::make_shared<Convergence>(convergence);
   if constexpr (sizeof...(auxvariables) == 0) {
     this->auxvariables_.clear();
@@ -132,19 +221,41 @@ ProblemBase<VAR, PST>::ProblemBase(const std::string& name, VAR& variables,
  * @tparam VAR Type representing the Variables.
  * @tparam PST Type representing the PostProcessing.
  * @tparam Args Types of auxiliary variables passed variadically.
- * @tparam CArgs Types of coefficients passed variadically.
  *
  * @param name Name of the problem.
  * @param variables Reference to the Variables object.
  * @param pst Reference to the PostProcessing object.
  * @param auxvariables Variadic pack of auxiliary variables.
- * @param Coeff Variadic pack of coefficients.
  */
 template <class VAR, class PST>
 template <PbVar<VAR>... Args>
 ProblemBase<VAR, PST>::ProblemBase(const std::string& name, VAR& variables, PST& pst,
                                    Args&&... auxvariables)
     : name_(name), variables_(variables), pst_(pst), convergence_(nullptr) {
+  if constexpr (sizeof...(auxvariables) == 0) {
+    this->auxvariables_.clear();
+  } else {
+    this->auxvariables_ = {&auxvariables...};
+  }
+  if (this->has_pst()) {
+    this->problem_post_processing_directory_ = this->get_pst().get_post_processing_directory();
+  }
+}
+/**
+ * @brief Constructs a new ProblemBase object.
+ *
+ * @tparam VAR Type representing the Variables.
+ * @tparam PST Type representing the PostProcessing.
+ * @tparam Args Types of auxiliary variables passed variadically.
+ *
+ * @param name Name of the problem.
+ * @param variables Reference to the Variables object.
+ * @param auxvariables Variadic pack of auxiliary variables.
+ */
+template <class VAR, class PST>
+template <PbVar<VAR>... Args>
+ProblemBase<VAR, PST>::ProblemBase(const std::string& name, VAR& variables, Args&&... auxvariables)
+    : name_(name), variables_(variables), pst_(std::nullopt), convergence_(nullptr) {
   if constexpr (sizeof...(auxvariables) == 0) {
     this->auxvariables_.clear();
   } else {
@@ -166,6 +277,32 @@ std::string ProblemBase<VAR, PST>::get_name() {
 }
 
 /**
+ *
+ * @brief Set the name of the problem
+ *
+ * @tparam VAR Type representing the Variables.
+ * @tparam PST Type representing the PostProcessing.
+ * @param std::string The name of the problem.
+ */
+template <class VAR, class PST>
+void ProblemBase<VAR, PST>::set_name(const std::string& new_name) {
+  this->name_ = new_name;
+}
+
+/**
+ *
+ * @brief Set the name for global specialized CSV file of the problem
+ *
+ * @tparam VAR Type representing the Variables.
+ * @tparam PST Type representing the PostProcessing.
+ * @param std::string The name of or global specialized CSV file of the problem
+ */
+template <class VAR, class PST>
+void ProblemBase<VAR, PST>::set_name_save_specialized(const std::string& new_name) {
+  this->name_save_specialized_ = new_name;
+}
+
+/**
  * @brief  Return the variables associated with the problem
  *
  * @tparam VAR Type representing the Variables.
@@ -175,6 +312,18 @@ std::string ProblemBase<VAR, PST>::get_name() {
 template <class VAR, class PST>
 VAR ProblemBase<VAR, PST>::get_problem_variables() {
   return this->variables_;
+}
+
+/**
+ * @brief Return the post-processing directory for the problem
+ *
+ * @tparam VAR Type representing the Variables.
+ * @tparam PST Type representing the PostProcessing.
+ * @return VAR The list of Variables of the problem.
+ */
+template <class VAR, class PST>
+std::string ProblemBase<VAR, PST>::get_problem_post_processing_directory() {
+  return this->problem_post_processing_directory_;
 }
 
 /**
@@ -329,8 +478,10 @@ void ProblemBase<VAR, PST>::check_convergence(
  */
 template <class VAR, class PST>
 void ProblemBase<VAR, PST>::save(const int iter, const double& current_time) {
-  auto vars = this->get_problem_variables();
-  this->pst_.save_variables(vars, iter, current_time);
+  if (this->has_pst()) {
+    auto vars = this->get_problem_variables();
+    this->get_pst().save_variables(vars, iter, current_time);
+  }
 }
 
 /**

--- a/kernel/include/Problems/PropertyProblem.hpp
+++ b/kernel/include/Problems/PropertyProblem.hpp
@@ -52,6 +52,7 @@ class Property_problem : public ProblemBase<VAR, PST> {
   std::vector<std::tuple<std::vector<std::string>, mfem::Vector>> get_input_system();
 
  public:
+  // With PST
   template <PbVar<VAR>... Args>
   Property_problem(const std::string& name, const Parameters& params, VAR& variables,
                    const std::vector<Coefficients>& Coeff, Convergence& convergence, PST& pst,
@@ -83,6 +84,39 @@ class Property_problem : public ProblemBase<VAR, PST> {
 
   template <PbVar<VAR>... Args>
   Property_problem(const Parameters& params, VAR& variables, PST& pst, Args&&... auxvariable);
+
+  // Without PST
+  template <PbVar<VAR>... Args>
+  Property_problem(const std::string& name, const Parameters& params, VAR& variables,
+                   const std::vector<Coefficients>& Coeff, Convergence& convergence,
+                   Args&&... auxvariable);
+
+  template <PbVar<VAR>... Args>
+  Property_problem(const Parameters& params, VAR& variables, const std::vector<Coefficients>& Coeff,
+                   Convergence& convergence, Args&&... auxvariable);
+
+  template <PbVar<VAR>... Args>
+  Property_problem(const std::string& name, const Parameters& params, VAR& variables,
+                   const std::vector<Coefficients>& Coeff, Args&&... auxvariable);
+
+  template <PbVar<VAR>... Args>
+  Property_problem(const Parameters& params, VAR& variables, const std::vector<Coefficients>& Coeff,
+                   Args&&... auxvariable);
+
+  template <PbVar<VAR>... Args>
+  Property_problem(const std::string& name, const Parameters& params, VAR& variables,
+                   Convergence& convergence, Args&&... auxvariable);
+
+  template <PbVar<VAR>... Args>
+  Property_problem(const Parameters& params, VAR& variables, Convergence& convergence,
+                   Args&&... auxvariable);
+
+  template <PbVar<VAR>... Args>
+  Property_problem(const std::string& name, const Parameters& params, VAR& variables,
+                   Args&&... auxvariable);
+
+  template <PbVar<VAR>... Args>
+  Property_problem(const Parameters& params, VAR& variables, Args&&... auxvariable);
 
   /////////////////////////////////////////////////////
   void initialize(const double& initial_time, const double time_step) override;

--- a/kernel/include/Problems/PropertyProblem.tpp
+++ b/kernel/include/Problems/PropertyProblem.tpp
@@ -65,6 +65,27 @@ Property_problem<PROPERTY, VAR, PST>::Property_problem(const Parameters& params,
                             auxvariables...) {
   this->PP_ = new PROPERTY(params);
 }
+/**
+ * @brief Construct a new Property_problem<PROPERTY, VAR, PST>::Property_problem object
+ *
+ * @tparam PROPERTY
+ * @tparam VAR
+ * @tparam PST
+ * @tparam Args
+ * @param params Parameters of the problem
+ * @param variables Variables of the problem
+ * @param convergence Convergence object of the problem
+ * @param auxvariables Auxiliary variables of the problem
+ */
+template <class PROPERTY, class VAR, class PST>
+template <PbVar<VAR>... Args>
+Property_problem<PROPERTY, VAR, PST>::Property_problem(const Parameters& params, VAR& variables,
+                                                       const std::vector<Coefficients>& Coeff,
+                                                       Convergence& convergence,
+                                                       Args&&... auxvariables)
+    : ProblemBase<VAR, PST>("PropertyProblem", variables, Coeff, convergence, auxvariables...) {
+  this->PP_ = new PROPERTY(params);
+}
 
 /**
  * @brief Construct a new Property_problem<PROPERTY, VAR, PST>::Property_problem object
@@ -84,6 +105,25 @@ Property_problem<PROPERTY, VAR, PST>::Property_problem(const Parameters& params,
                                                        const std::vector<Coefficients>& Coeff,
                                                        PST& pst, Args&&... auxvariables)
     : ProblemBase<VAR, PST>("PropertyProblem", variables, Coeff, pst, auxvariables...) {
+  this->PP_ = new PROPERTY(params);
+}
+/**
+ * @brief Construct a new Property_problem<PROPERTY, VAR, PST>::Property_problem object
+ *
+ * @tparam PROPERTY
+ * @tparam VAR
+ * @tparam PST
+ * @tparam Args
+ * @param params Parameters of the problem
+ * @param variables Variables of the problem
+ * @param auxvariables Auxiliary variables of the problem
+ */
+template <class PROPERTY, class VAR, class PST>
+template <PbVar<VAR>... Args>
+Property_problem<PROPERTY, VAR, PST>::Property_problem(const Parameters& params, VAR& variables,
+                                                       const std::vector<Coefficients>& Coeff,
+                                                       Args&&... auxvariables)
+    : ProblemBase<VAR, PST>("PropertyProblem", variables, Coeff, auxvariables...) {
   this->PP_ = new PROPERTY(params);
 }
 
@@ -111,6 +151,29 @@ Property_problem<PROPERTY, VAR, PST>::Property_problem(const std::string& name,
     : ProblemBase<VAR, PST>(name, variables, Coeff, convergence, pst, auxvariables...) {
   this->PP_ = new PROPERTY(params);
 }
+/**
+ * @brief Construct a new Property_problem<PROPERTY, VAR, PST>::Property_problem object
+ *
+ * @tparam PROPERTY
+ * @tparam VAR
+ * @tparam PST
+ * @tparam Args
+ * @param name User-defined name of the property problem
+ * @param params Parameters of the problem
+ * @param variables Variables of the problem
+ * @param convergence Convergence object of the problem
+ * @param auxvariables Auxiliary variables of the problem
+ */
+template <class PROPERTY, class VAR, class PST>
+template <PbVar<VAR>... Args>
+Property_problem<PROPERTY, VAR, PST>::Property_problem(const std::string& name,
+                                                       const Parameters& params, VAR& variables,
+                                                       const std::vector<Coefficients>& Coeff,
+                                                       Convergence& convergence,
+                                                       Args&&... auxvariables)
+    : ProblemBase<VAR, PST>(name, variables, Coeff, convergence, auxvariables...) {
+  this->PP_ = new PROPERTY(params);
+}
 
 /**
  * @brief Construct a new Property_problem<PROPERTY, VAR, PST>::Property_problem object
@@ -134,6 +197,27 @@ Property_problem<PROPERTY, VAR, PST>::Property_problem(const std::string& name,
     : ProblemBase<VAR, PST>(name, variables, Coeff, pst, auxvariables...) {
   this->PP_ = new PROPERTY(params);
 }
+/**
+ * @brief Construct a new Property_problem<PROPERTY, VAR, PST>::Property_problem object
+ *
+ * @tparam PROPERTY
+ * @tparam VAR
+ * @tparam PST
+ * @tparam Args
+ * @param name User-defined name of the property problem
+ * @param params Parameters of the problem
+ * @param variables Variables of the problem
+ * @param auxvariables Auxiliary variables of the problem
+ */
+template <class PROPERTY, class VAR, class PST>
+template <PbVar<VAR>... Args>
+Property_problem<PROPERTY, VAR, PST>::Property_problem(const std::string& name,
+                                                       const Parameters& params, VAR& variables,
+                                                       const std::vector<Coefficients>& Coeff,
+                                                       Args&&... auxvariables)
+    : ProblemBase<VAR, PST>(name, variables, Coeff, auxvariables...) {
+  this->PP_ = new PROPERTY(params);
+}
 
 /**
  * @brief Construct a new Property_problem<PROPERTY, VAR, PST>::Property_problem object
@@ -154,6 +238,26 @@ Property_problem<PROPERTY, VAR, PST>::Property_problem(const Parameters& params,
                                                        Convergence& convergence, PST& pst,
                                                        Args&&... auxvariables)
     : ProblemBase<VAR, PST>("PropertyProblem", variables, convergence, pst, auxvariables...) {
+  this->PP_ = new PROPERTY(params);
+}
+/**
+ * @brief Construct a new Property_problem<PROPERTY, VAR, PST>::Property_problem object
+ *
+ * @tparam PROPERTY
+ * @tparam VAR
+ * @tparam PST
+ * @tparam Args
+ * @param params Parameters of the problem
+ * @param variables Variables of the problem
+ * @param convergence Convergence object of the problem
+ * @param auxvariables Auxiliary variables of the problem
+ */
+template <class PROPERTY, class VAR, class PST>
+template <PbVar<VAR>... Args>
+Property_problem<PROPERTY, VAR, PST>::Property_problem(const Parameters& params, VAR& variables,
+                                                       Convergence& convergence,
+                                                       Args&&... auxvariables)
+    : ProblemBase<VAR, PST>("PropertyProblem", variables, convergence, auxvariables...) {
   this->PP_ = new PROPERTY(params);
 }
 
@@ -184,6 +288,25 @@ Property_problem<PROPERTY, VAR, PST>::Property_problem(const Parameters& params,
  * @tparam VAR
  * @tparam PST
  * @tparam Args
+ * @param params Parameters of the problem
+ * @param variables Variables of the problem
+ * @param auxvariables Auxiliary variables of the problem
+ */
+template <class PROPERTY, class VAR, class PST>
+template <PbVar<VAR>... Args>
+Property_problem<PROPERTY, VAR, PST>::Property_problem(const Parameters& params, VAR& variables,
+                                                       Args&&... auxvariables)
+    : ProblemBase<VAR, PST>("PropertyProblem", variables, auxvariables...) {
+  this->PP_ = new PROPERTY(params);
+}
+
+/**
+ * @brief Construct a new Property_problem<PROPERTY, VAR, PST>::Property_problem object
+ *
+ * @tparam PROPERTY
+ * @tparam VAR
+ * @tparam PST
+ * @tparam Args
  * @param name User-defined name of the property problem
  * @param params Parameters of the problem
  * @param variables Variables of the problem
@@ -198,6 +321,28 @@ Property_problem<PROPERTY, VAR, PST>::Property_problem(const std::string& name,
                                                        Convergence& convergence, PST& pst,
                                                        Args&&... auxvariables)
     : ProblemBase<VAR, PST>(name, variables, convergence, pst, auxvariables...) {
+  this->PP_ = new PROPERTY(params);
+}
+/**
+ * @brief Construct a new Property_problem<PROPERTY, VAR, PST>::Property_problem object
+ *
+ * @tparam PROPERTY
+ * @tparam VAR
+ * @tparam PST
+ * @tparam Args
+ * @param name User-defined name of the property problem
+ * @param params Parameters of the problem
+ * @param variables Variables of the problem
+ * @param convergence Convergence object of the problem
+ * @param auxvariables Auxiliary variables of the problem
+ */
+template <class PROPERTY, class VAR, class PST>
+template <PbVar<VAR>... Args>
+Property_problem<PROPERTY, VAR, PST>::Property_problem(const std::string& name,
+                                                       const Parameters& params, VAR& variables,
+                                                       Convergence& convergence,
+                                                       Args&&... auxvariables)
+    : ProblemBase<VAR, PST>(name, variables, convergence, auxvariables...) {
   this->PP_ = new PROPERTY(params);
 }
 
@@ -222,6 +367,29 @@ Property_problem<PROPERTY, VAR, PST>::Property_problem(const std::string& name,
                                                        const Parameters& params, VAR& variables,
                                                        PST& pst, Args&&... auxvariables)
     : ProblemBase<VAR, PST>(name, variables, pst, auxvariables...) {
+  this->PP_ = new PROPERTY(params);
+}
+
+/**
+ * @brief Construct a new Property_problem<PROPERTY, VAR, PST>::Property_problem object
+ *
+ * @tparam PROPERTY
+ * @tparam VAR
+ *   Primary variable container type.
+ * @tparam PST
+ *   PostProcessing.
+ * @tparam Args
+ * @param name User-defined name of the property problem
+ * @param params Parameters of the problem
+ * @param variables Variables of the problem
+ * @param auxvariables Auxiliary variables of the problem
+ */
+template <class PROPERTY, class VAR, class PST>
+template <PbVar<VAR>... Args>
+Property_problem<PROPERTY, VAR, PST>::Property_problem(const std::string& name,
+                                                       const Parameters& params, VAR& variables,
+                                                       Args&&... auxvariables)
+    : ProblemBase<VAR, PST>(name, variables, auxvariables...) {
   this->PP_ = new PROPERTY(params);
 }
 

--- a/kernel/include/Time/Time.hpp
+++ b/kernel/include/Time/Time.hpp
@@ -66,7 +66,8 @@ class TimeDiscretization {
   void finalize();
   void time_management();
   void time_info(const int& iter);
-
+  void check_duplicate_coupling_name();
+  void check_duplicate_post_processing_directory();
   std::function<double(double)> time_step_function_;
 
  public:

--- a/kernel/include/Time/Time.tpp
+++ b/kernel/include/Time/Time.tpp
@@ -53,6 +53,9 @@ TimeDiscretization<Args...>::TimeDiscretization(const Parameters& params, Args..
 
   this->time_step_function_ =
       std::function<double(double)>([this](double) { return this->time_step_; });
+
+  this->check_duplicate_coupling_name();
+  this->check_duplicate_post_processing_directory();
 }
 
 /**
@@ -248,6 +251,51 @@ void TimeDiscretization<Args...>::time_info(const int& iter) {
     SlothInfo::verbose("     - time-step requested : ", this->time_step_);
     SlothInfo::verbose("     - time-step accepted  : ", this->current_time_step_);
   }
+}
+
+/**
+ * @brief Checks for duplicate coupling names and renames duplicates.
+ *
+ */
+template <class... Args>
+void TimeDiscretization<Args...>::check_duplicate_coupling_name() {
+  std::set<std::string> coupling_names;
+
+  std::apply(
+      [&](auto&... coupling) {
+        (
+            [&] {
+              const std::string original_name = coupling.get_name();
+              std::string new_name = original_name;
+
+              int suffix = 0;
+              while (coupling_names.contains(new_name)) {
+                new_name = original_name + std::to_string(++suffix);
+              }
+
+              if (new_name != original_name) {
+                coupling.set_name(new_name);
+              }
+
+              coupling_names.insert(new_name);
+            }(),
+            ...);
+      },
+      couplings_);
+}
+
+/**
+ * @brief Checks for duplicate post-processing directories and add prefix to avoid duplicates in CSV
+ * files.
+ */
+template <class... Args>
+void TimeDiscretization<Args...>::check_duplicate_post_processing_directory() {
+  const std::size_t nb_couplings = std::tuple_size_v<decltype(couplings_)>;
+  std::apply(
+      [&](auto&... coupling) {
+        (coupling.check_duplicate_post_processing_directory(nb_couplings), ...);
+      },
+      couplings_);
 }
 
 /**

--- a/kernel/include/Utils/UtilsForData.hpp
+++ b/kernel/include/Utils/UtilsForData.hpp
@@ -106,6 +106,20 @@ inline std::string trim(const std::string& str) {
   return (start >= end) ? "" : std::string(start, end);
 }
 
+/**
+ * @brief Replaces whitespace characters with underscores.
+ *
+ * @param str The input string.
+ * @return A copy of the input string with whitespace replaced by `_`
+ *
+ */
+inline std::string replaceSpaces(std::string str) {
+  std::ranges::replace_if(
+      str, [](char c) { return std::isspace(static_cast<unsigned char>(c)); }, '_');
+
+  return str;
+}
+
 /////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
### Optional post-processing

PostProcessing objects are optional.

**Problem definition with post-processing:**

```c++
auto ch_pst = PST(&spatial, ch_p_pst);
PB ch_pb("CahnHilliard", ch_oper, ch_vars, {ch_coef, ch_coef}, ch_pst, ac_vars);
```

**Problem definition without post-processing:**


```c++
PB ch_pb("CahnHilliard", ch_oper, ch_vars, {ch_coef, ch_coef}, ac_vars);
```

### Common directory and Paraview file for multiphysics simulations

A common PostProcessing can be shared between multiple problems.

**Definition of two problems with separate post-processing objects:**
```c++
auto ch_pst = PST(&spatial, ch_p_pst);
PB ch_pb("CahnHilliard", ch_oper, ch_vars, {ch_coef, ch_coef}, ch_pst, ac_vars);

auto ac_pst = PST(&spatial, ac_p_pst);
PB ac_pb("AllenCahn", ac_oper, ac_vars, {ac_coef, ac_coef}, ac_pst, ch_vars);
```

In this case, the variables for the Cahn-Hilliard and Allen-Cahn problems are saved in two separate VTK files. If required, the global specialized file, `time_specialized.csv`, is also generated separately in each problem's post-processing directory.

**Definition of two problems sharing a common post-processing object:**
```c++
auto common_pst = PST(&spatial, p_pst);

PB ch_pb("CahnHilliard", ch_oper, ch_vars, {ch_coef, ch_coef}, common_pst, ac_vars);
PB ac_pb("AllenCahn", ac_oper, ac_vars, {ac_coef, ac_coef}, common_pst, ch_vars);
```

In this case, the variables for both the Cahn-Hilliard and Allen-Cahn problems are saved in the same VTK file. If required, the global specialized files for both problems are generated in the common post-processing directory.

To avoid naming conflicts and duplicated files, the generated specialized files are automatically prefixed with the name of the corresponding Problem and, when applicable, with the name of the coupling.