### PR TITLE
Fix compatibility between AMR and unified VTK file

### DIFF
--- a/kernel/include/AMR/SlothErrorEstimators.hpp
+++ b/kernel/include/AMR/SlothErrorEstimators.hpp
@@ -43,6 +43,8 @@ class SlothErrorEstimators {
   mfem::BilinearFormIntegrator* integ_{nullptr};
   mfem::ParFiniteElementSpace* flux_fes_{nullptr};
   mfem::ParFiniteElementSpace* smooth_flux_fes_{nullptr};
+  mfem::FiniteElementCollection* flux_fec_{nullptr};
+  mfem::FiniteElementCollection* smooth_flux_fec_{nullptr};
 
  public:
   SlothErrorEstimators(ErrorEstimatorType value, mfem::BilinearFormIntegrator* integ);

--- a/kernel/include/Couplings/Coupling.hpp
+++ b/kernel/include/Couplings/Coupling.hpp
@@ -58,19 +58,26 @@ class Coupling {
   void check_duplicate_problem_name();
 
  public:
+  explicit Coupling(const std::string& name, Args... problems);
+
   std::vector<VAR*> CollectAllVariables();
   using VarType = VAR;
-  explicit Coupling(const std::string& name, Args... problems);
+
   std::string get_name();
   void set_name(const std::string& new_name);
   void get_tree();
   void initialize(const int& iter, const double& initial_time, const double time_step,
-                  std::vector<VAR*> all_vars);
-  void check_duplicate_post_processing_directory(std::size_t nb_couplings);
+                  bool vtk_unified, std::vector<VAR*> all_vars);
+  void collect_vtk_fields(std::map<std::string, mfem::ParGridFunction*>& all_fields);
+  auto get_shared_dc() { return std::get<0>(this->problems_).get_shared_dc(); }
+  void check_duplicate_post_processing_directory(std::size_t nb_couplings,
+                                                 const std::map<std::string, int>& directory_count);
+  void get_post_processing_directory_count(std::map<std::string, int>& directory_count);
   void execute(const int& iter, double& next_time, const double& current_time,
                const double& current_time_step);
   void update();
-  void post_processing(const int& iter, const double& current_time, std::vector<VAR*> all_vars);
+  void post_processing(const int& iter, const double& current_time, bool vtk_unified,
+                       std::vector<VAR*> all_vars);
   void finalize();
 
   std::vector<std::tuple<std::string, std::vector<std::tuple<std::string, bool, double>>>>

--- a/kernel/include/Couplings/Coupling.tpp
+++ b/kernel/include/Couplings/Coupling.tpp
@@ -41,7 +41,6 @@
  * @tparam Args Types of the problems stored in the coupling.
  * @param problems
  */
-// Coupling<Args...>::Coupling(const std::string& name, Args&&... problems)
 template <class... Args>
 Coupling<Args...>::Coupling(const std::string& name, Args... problems)
     : name_(name), problems_(std::make_tuple(std::forward<Args>(problems)...)) {
@@ -109,8 +108,40 @@ void Coupling<Args...>::check_duplicate_problem_name() {
  * @tparam Args Types of the problems stored in the coupling.
  */
 template <class... Args>
-void Coupling<Args...>::check_duplicate_post_processing_directory(std::size_t nb_couplings) {
-  std::map<std::string, int> directory_count;
+void Coupling<Args...>::check_duplicate_post_processing_directory(
+    std::size_t nb_couplings, const std::map<std::string, int>& directory_count) {
+  std::apply(
+      [&](auto&... problem) {
+        (
+            [&] {
+              const std::string pb_dir = problem.get_problem_post_processing_directory();
+              if (!pb_dir.empty() && directory_count.contains(pb_dir) &&
+                  directory_count.at(pb_dir) > 1) {
+                std::string name =
+                    replacePunctuation(replaceSpaces(problem.get_name())) + "_time_specialized.csv";
+                if (nb_couplings > 1) {
+                  name = replacePunctuation(replaceSpaces(this->get_name())) + "_" + name;
+                }
+                problem.set_name_save_specialized(name);
+              }
+            }(),
+            ...);
+      },
+      problems_);
+}
+
+/**
+ * @brief Count how many Problems in this coupling write to each
+ *        post-processing directory.
+ *
+ * @tparam Args Problem types in this coupling.
+ * @param directory_count Output map, incremented once per Problem whose
+ *                        directory is non-empty (accumulated, not
+ *                        cleared by this call).
+ */
+template <class... Args>
+void Coupling<Args...>::get_post_processing_directory_count(
+    std::map<std::string, int>& directory_count) {
   std::apply(
       [&](auto&... problem) {
         (
@@ -119,23 +150,6 @@ void Coupling<Args...>::check_duplicate_post_processing_directory(std::size_t nb
 
               if (!pb_dir.empty()) {
                 ++directory_count[pb_dir];
-              }
-            }(),
-            ...);
-      },
-      problems_);
-
-  std::apply(
-      [&](auto&... problem) {
-        (
-            [&] {
-              const std::string pb_dir = problem.get_problem_post_processing_directory();
-              if (!pb_dir.empty() && directory_count[pb_dir] > 1) {
-                std::string name = replaceSpaces(problem.get_name()) + "_time_specialized.csv";
-                if (nb_couplings > 1) {
-                  name = replaceSpaces(this->get_name()) + "_" + name;
-                }
-                problem.set_name_save_specialized(name);
               }
             }(),
             ...);
@@ -172,14 +186,24 @@ void Coupling<Args...>::get_tree() {
  */
 template <class... Args>
 void Coupling<Args...>::initialize(const int& iter, const double& initial_time,
-                                   const double time_step, std::vector<VAR*> all_vars) {
-  std::apply(
-      [iter, initial_time, time_step, all_vars](auto&... problem) {
-        (problem.initialize(initial_time, time_step), ...);
-        (problem.initialize_amr(all_vars), ...);
-        (void([&problem, iter, initial_time] { problem.save(iter, initial_time); }()), ...);
-      },
-      problems_);
+                                   const double time_step, bool vtk_unified,
+                                   std::vector<VAR*> all_vars) {
+  if (vtk_unified) {
+    std::apply(
+        [iter, initial_time, time_step, all_vars](auto&... problem) {
+          (problem.initialize(initial_time, time_step), ...);
+          (problem.initialize_amr(all_vars), ...);
+        },
+        problems_);
+  } else {
+    std::apply(
+        [iter, initial_time, time_step, all_vars](auto&... problem) {
+          (problem.initialize(initial_time, time_step), ...);
+          (problem.initialize_amr(all_vars), ...);
+          (void([&problem, iter, initial_time] { problem.save_vtk(iter, initial_time); }()), ...);
+        },
+        problems_);
+  }
 }
 
 /**
@@ -198,6 +222,22 @@ std::vector<typename Coupling<Args...>::VAR*> Coupling<Args...>::CollectAllVaria
                  auto&... problem) { (all_vars.push_back(&problem.get_problem_variables()), ...); },
              this->problems_);
   return all_vars;
+}
+
+/**
+ * @brief Collect the grid functions of every Problem in this coupling
+ *        into a shared field map.
+ *
+ * @tparam Args Problem types in this coupling.
+ * @param all_fields Output map, accumulated across every Problem, for a
+ *                   single unified VTK save (see
+ *                   `TimeDiscretization::save_vtk_unified()`).
+ */
+template <class... Args>
+void Coupling<Args...>::collect_vtk_fields(
+    std::map<std::string, mfem::ParGridFunction*>& all_fields) {
+  std::apply([&all_fields](auto&... problem) { (problem.collect_vtk_fields(all_fields), ...); },
+             this->problems_);
 }
 
 /**
@@ -265,10 +305,10 @@ void Coupling<Args...>::update() {
  */
 template <class... Args>
 void Coupling<Args...>::post_processing(const int& iter, const double& current_time,
-                                        std::vector<VAR*> all_vars) {
+                                        bool vtk_unified, std::vector<VAR*> all_vars) {
   std::apply(
-      [iter, current_time, all_vars](auto&... problem) {
-        (problem.post_processing(iter, current_time), ...);
+      [iter, current_time, vtk_unified, all_vars](auto&... problem) {
+        (problem.post_processing(iter, current_time, vtk_unified), ...);
         (problem.save_amr(all_vars), ...);
       },
       problems_);

--- a/kernel/include/PostProcessing/postprocessing.hpp
+++ b/kernel/include/PostProcessing/postprocessing.hpp
@@ -75,7 +75,11 @@ class PostProcessing {
   const Parameters& params_;
   std::map<std::string, mfem::ParGridFunction> fields_to_save_;
   std::string post_processing_directory_;
+
   void get_parameters();
+  void get_specialized_parameters();
+  void get_restart_parameters();
+  void get_common_parameters();
 
   bool need_to_be_saved(const int iteration, const double time);
 
@@ -88,7 +92,7 @@ class PostProcessing {
   PostProcessing& operator=(PostProcessing&&) = default;
 
   PostProcessing(SpatialDiscretization<T, DIM>* space, const Parameters& params);
-  void save_variables(const Variables<T, DIM>& vars, const int& iter, const double& time);
+  void save_variables(Variables<T, DIM>& vars, const int& iter, const double& time);
   void save_specialized(const std::multimap<IterationKey, SpecializedValue>& mmap_results,
                         std::string filename = "time_specialized.csv");
   void save_iso_specialized(const std::multimap<IterationKey, SpecializedValue>& mmap_results,
@@ -101,6 +105,10 @@ class PostProcessing {
   std::map<std::string, std::tuple<double, double>> get_integral_to_compute();
 
   virtual ~PostProcessing() = default;
+
+  void collect_vtk_fields(Variables<T, DIM>& vars,
+                          std::map<std::string, mfem::ParGridFunction*>& all_fields);
+  std::shared_ptr<DC> get_shared_dc();
 };
 
 #include "PostProcessing/postprocessing.tpp"

--- a/kernel/include/PostProcessing/postprocessing.tpp
+++ b/kernel/include/PostProcessing/postprocessing.tpp
@@ -71,28 +71,16 @@ PostProcessing<T, DC, DIM>::PostProcessing(SpatialDiscretization<T, DIM>* space,
 }
 
 /**
- * @brief Get parameters for PostProcessing object
+ * @brief Get specialized parameters
  *
  * @tparam T mfem FECollection
  * @tparam DC mfem DataCollection
  * @tparam DIM Spatial dimension
  */
 template <class T, class DC, int DIM>
-void PostProcessing<T, DC, DIM>::get_parameters() {
-  this->main_folder_path_ = this->params_.template get_param_value<std::string>("main_folder_path");
-  this->calculation_path_ = this->params_.template get_param_value<std::string>("calculation_path");
-
-  this->level_of_detail_ =
-      this->params_.template get_param_value_or_default<int>("level_of_detail", 1);
-
+void PostProcessing<T, DC, DIM>::get_specialized_parameters() {
   this->enable_compute_energies_ =
       this->params_.template get_param_value_or_default<bool>("enable_compute_energies", true);
-
-  this->enable_save_specialized_at_iter_ = this->params_.template get_param_value_or_default<bool>(
-      "enable_save_specialized_at_iter", true);
-
-  this->force_clean_output_dir_ =
-      this->params_.template get_param_value_or_default<bool>("force_clean_output_dir", false);
 
   if (this->params_.has_parameter("iso_val_to_compute")) {
     this->iso_val_to_compute_ =
@@ -109,7 +97,49 @@ void PostProcessing<T, DC, DIM>::get_parameters() {
       MFEM_VERIFY(upper_bound >= lower_bound, error_msg.c_str());
     }
   }
+}
+/**
+ * @brief Get restart parameters
+ *
+ * @tparam T mfem FECollection
+ * @tparam DC mfem DataCollection
+ * @tparam DIM Spatial dimension
+ */
+template <class T, class DC, int DIM>
+void PostProcessing<T, DC, DIM>::get_restart_parameters() {
+  if (this->params_.has_parameter("iterations_list_save_gf")) {
+    this->iterations_list_save_gf_ =
+        this->params_.template get_param_value<vInt>("iterations_list_save_gf");
 
+    this->gf_folder_path_ =
+        this->params_.template get_param_value_or_default<std::string>("gf_folder_path", "GF");
+
+    std::filesystem::path dir = this->gf_folder_path_;
+    if (!std::filesystem::exists(dir)) {
+      std::filesystem::create_directories(dir);
+    }
+  }
+}
+
+/**
+ * @brief Get common parameters
+ *
+ * @tparam T mfem FECollection
+ * @tparam DC mfem DataCollection
+ * @tparam DIM Spatial dimension
+ */
+template <class T, class DC, int DIM>
+void PostProcessing<T, DC, DIM>::get_common_parameters() {
+  this->main_folder_path_ = this->params_.template get_param_value<std::string>("main_folder_path");
+  this->calculation_path_ = this->params_.template get_param_value<std::string>("calculation_path");
+
+  this->level_of_detail_ =
+      this->params_.template get_param_value_or_default<int>("level_of_detail", 1);
+  this->force_clean_output_dir_ =
+      this->params_.template get_param_value_or_default<bool>("force_clean_output_dir", false);
+
+  this->enable_save_specialized_at_iter_ = this->params_.template get_param_value_or_default<bool>(
+      "enable_save_specialized_at_iter", true);
   std::string error_msg =
       "At least one the following parameter is expected: frequency, iterations_list, times_list";
   MFEM_VERIFY(this->params_.has_parameter("frequency") ||
@@ -127,20 +157,25 @@ void PostProcessing<T, DC, DIM>::get_parameters() {
       this->times_list_ = this->params_.template get_param_value<vDouble>("times_list");
     }
   }
+}
+
+/**
+ * @brief Get parameters for PostProcessing object
+ *
+ * @tparam T mfem FECollection
+ * @tparam DC mfem DataCollection
+ * @tparam DIM Spatial dimension
+ */
+template <class T, class DC, int DIM>
+void PostProcessing<T, DC, DIM>::get_parameters() {
+  // Global
+  this->get_common_parameters();
+
+  // Specialized (CSV)
+  this->get_specialized_parameters();
 
   // Restart
-  if (this->params_.has_parameter("iterations_list_save_gf")) {
-    this->iterations_list_save_gf_ =
-        this->params_.template get_param_value<vInt>("iterations_list_save_gf");
-
-    this->gf_folder_path_ =
-        this->params_.template get_param_value_or_default<std::string>("gf_folder_path", "GF");
-
-    std::filesystem::path dir = this->gf_folder_path_;
-    if (!std::filesystem::exists(dir)) {
-      std::filesystem::create_directories(dir);
-    }
-  }
+  this->get_restart_parameters();
 }
 
 /**
@@ -154,27 +189,27 @@ void PostProcessing<T, DC, DIM>::get_parameters() {
  * @param time
  */
 template <class T, class DC, int DIM>
-void PostProcessing<T, DC, DIM>::save_variables(const Variables<T, DIM>& vars, const int& iter,
+void PostProcessing<T, DC, DIM>::save_variables(Variables<T, DIM>& vars, const int& iter,
                                                 const double& time) {
   // VTK
   if (this->need_to_be_saved(iter, time)) {
     this->dc_->SetCycle(iter);
     this->dc_->SetTime(time);
-    std::map<std::string, mfem::ParGridFunction> map_var = vars.get_map_gridfunction();
-    for (auto& [name, gf] : map_var) {
-      this->dc_->RegisterField(name, &gf);
+    std::map<std::string, mfem::ParGridFunction*> map_var = vars.get_map_gridfunction();
+    for (auto& [name, gf_ptr] : map_var) {
+      this->dc_->RegisterField(name, gf_ptr);
     }
     this->dc_->Save();
   }
   // Restart
   if (std::ranges::find(this->iterations_list_save_gf_, iter) !=
       this->iterations_list_save_gf_.end()) {
-    std::map<std::string, mfem::ParGridFunction> map_var = vars.get_map_gridfunction();
+    std::map<std::string, mfem::ParGridFunction*> map_var = vars.get_map_gridfunction();
     std::filesystem::path output_dir_path(this->gf_folder_path_);
-    for (auto& [name, gf] : map_var) {
+    for (auto& [name, gf_ptr] : map_var) {
       std::filesystem::path filename = name + "_" + std::to_string(iter) + ".gf";
       std::filesystem::path full_path = output_dir_path / filename;
-      gf.Save(full_path.string().c_str(), 16);
+      gf_ptr->Save(full_path.string().c_str(), 16);
     }
   }
 }
@@ -374,4 +409,34 @@ void PostProcessing<T, DC, DIM>::clean_output_directory() {
       }
     }
   }
+}
+
+/**
+ * @brief Collect this Problem's grid functions into a shared field map.
+ *
+ * @tparam T mfem FECollection
+ * @tparam DC mfem DataCollection
+ * @tparam DIM Spatial dimension
+ * @param vars Variables to collect fields from.
+ * @param all_fields Output map, accumulated across multiple Problems for
+ *                   a unified VTK save (not cleared by this call).
+ */
+template <class T, class DC, int DIM>
+void PostProcessing<T, DC, DIM>::collect_vtk_fields(
+    Variables<T, DIM>& vars, std::map<std::string, mfem::ParGridFunction*>& all_fields) {
+  auto map_var = vars.get_map_gridfunction();
+  all_fields.insert(map_var.begin(), map_var.end());
+}
+
+/**
+ * @brief Return the shared DataCollection used for VTK output.
+ *
+ * @tparam T mfem FECollection
+ * @tparam DC mfem DataCollection
+ * @tparam DIM Spatial dimension
+ * @return std::shared_ptr<DC> The DataCollection instance.
+ */
+template <class T, class DC, int DIM>
+std::shared_ptr<DC> PostProcessing<T, DC, DIM>::get_shared_dc() {
+  return this->dc_;
 }

--- a/kernel/include/PostProcessing/postprocessing.tpp
+++ b/kernel/include/PostProcessing/postprocessing.tpp
@@ -68,6 +68,15 @@ PostProcessing<T, DC, DIM>::PostProcessing(SpatialDiscretization<T, DIM>* space,
   this->dc_->SetDataFormat(mfem::VTKFormat::BINARY);
   this->dc_->SetHighOrderOutput(true);
   this->post_processing_directory_ = this->main_folder_path_ + "/" + this->calculation_path_;
+
+  if (mfem::Mpi::WorldRank() == 0) {
+    std::filesystem::path dir_path = std::filesystem::path(this->post_processing_directory_);
+    if (!std::filesystem::exists(dir_path)) {
+      std::filesystem::create_directories(dir_path);
+    }
+  }
+  // Wait creation of the directory before continue
+  MPI_Barrier(MPI_COMM_WORLD);
 }
 
 /**
@@ -342,6 +351,7 @@ void PostProcessing<T, DC, DIM>::save_specialized(
     std::ostringstream text2fic;
     // File doesn't exist
     std::ofstream fic(file, std::ios::out);
+
     if (fic.is_open()) {
       ////////////////////////////////////////////
       // Headers

--- a/kernel/include/Problems/Calphad_problem.hpp
+++ b/kernel/include/Problems/Calphad_problem.hpp
@@ -150,7 +150,7 @@ class Calphad_Problem : public ProblemBase<VAR, PST> {
 
   /////////////////////////////////////////////////////
 
-  void post_processing(const int& iter, const double& current_time) override;
+  void save_csv(const int iter, const double current_time) override;
   /////////////////////////////////////////////////////
   void finalize() override;
   /////////////////////////////////////////////////////

--- a/kernel/include/Problems/Calphad_problem.tpp
+++ b/kernel/include/Problems/Calphad_problem.tpp
@@ -777,7 +777,7 @@ void Calphad_Problem<CALPHAD, VAR, PST>::finalize() {
   this->CC_->finalize();
   int rank = mfem::Mpi::WorldRank();
   if (rank == 0 && this->has_pst()) {
-    if (!this->get_pst().get_enable_save_specialized_at_iter()) {
+    if (!this->get_pst().get_enable_save_specialized_at_iter() && this->enable_time_specialized_) {
       auto time_spe_mmap = this->CC_->get_time_specialized();
       if (!time_spe_mmap.empty()) {
         std::string str = "calphad.csv";
@@ -798,12 +798,11 @@ void Calphad_Problem<CALPHAD, VAR, PST>::finalize() {
  * @param current_time_step
  */
 template <class CALPHAD, class VAR, class PST>
-void Calphad_Problem<CALPHAD, VAR, PST>::post_processing(const int& iter,
-                                                         const double& current_time) {
+void Calphad_Problem<CALPHAD, VAR, PST>::save_csv(const int iter, const double current_time) {
   if (this->has_pst()) {
     int rank = mfem::Mpi::WorldRank();
     if (rank == 0) {
-      if (this->get_pst().get_enable_save_specialized_at_iter()) {
+      if (this->get_pst().get_enable_save_specialized_at_iter() && this->enable_time_specialized_) {
         auto time_spe_mmap = this->CC_->get_time_specialized();
         if (!time_spe_mmap.empty()) {
           std::string str = "calphad.csv";
@@ -815,8 +814,6 @@ void Calphad_Problem<CALPHAD, VAR, PST>::post_processing(const int& iter,
       this->CC_->clear_time_specialized();
     }
   }
-  // Save for visualization
-  ProblemBase<VAR, PST>::post_processing(iter, current_time);
 }
 
 /**

--- a/kernel/include/Problems/Problem.hpp
+++ b/kernel/include/Problems/Problem.hpp
@@ -105,11 +105,9 @@ class Problem : public ProblemBase<VAR, PST> {
                     const int iter, std::vector<std::unique_ptr<mfem::Vector>>& unks,
                     const std::vector<std::vector<std::string>>& unks_info) override;
 
-  void post_processing(const int& iter, const double& current_time) override;
+  void save_csv(const int iter, const double current_time) override;
 
   void finalize() override;
-
-  void save(const int iter, const double& current_time) override;
 };
 
 #include "Problems/Problem.tpp"

--- a/kernel/include/Problems/Problem.tpp
+++ b/kernel/include/Problems/Problem.tpp
@@ -437,19 +437,6 @@ template <class OPE, class VAR, class PST>
 void Problem<OPE, VAR, PST>::initialize(const double& initial_time, const double time_step) {
   this->oper_.initialize(initial_time, time_step, this->variables_, this->auxvariables_);
 }
-/**
- * @brief
- *
- * @tparam OPE
- * @tparam VAR
- * @tparam PST
- * @param iter
- * @param current_time
- */
-template <class OPE, class VAR, class PST>
-void Problem<OPE, VAR, PST>::save(const int iter, const double& current_time) {
-  ProblemBase<VAR, PST>::save(iter, current_time);
-}
 
 /**
  * @brief Finalize the Problem
@@ -490,7 +477,7 @@ void Problem<OPE, VAR, PST>::save_specialized(bool must_be_saved) {
   int rank = mfem::Mpi::WorldRank();
   if (rank == 0) {
     if (must_be_saved) {
-      if (!this->oper_.get_time_specialized().empty()) {
+      if (!this->oper_.get_time_specialized().empty() && this->enable_time_specialized_) {
         this->get_pst().save_specialized(this->oper_.get_time_specialized(),
                                          this->name_save_specialized_);
       }
@@ -524,7 +511,7 @@ void Problem<OPE, VAR, PST>::save_specialized(bool must_be_saved) {
  *
  */
 template <class OPE, class VAR, class PST>
-void Problem<OPE, VAR, PST>::post_processing(const int& iter, const double& current_time) {
+void Problem<OPE, VAR, PST>::save_csv(const int iter, const double current_time) {
   if (this->has_pst()) {
     const auto nvars = this->variables_.get_variables_number();
     std::vector<mfem::Vector> u_vect;
@@ -543,21 +530,23 @@ void Problem<OPE, VAR, PST>::post_processing(const int& iter, const double& curr
       auto unk = vv.get_unknown();
       auto unk_name = vv.getVariableName();
 
-      // Errors
+      // Errors : automatically done if an analytical solution is provided in Variable's definition
       if (solution != nullptr) {
         auto solution_func = solution.get();
         this->oper_.ComputeError(iter, current_time, current_time_step, iv, unk_name, unk,
                                  *solution_func);
       }
 
-      // Isovalues
+      // Isovalues : control at the uppest level of the scheme; automatically disable if Problem's
+      // variables are not given
       if (!map_iso_value.empty() && map_iso_value.contains(unk_name)) {
         const double iso_value = map_iso_value.at(unk_name);
         this->oper_.ComputeIsoVal(iter, current_time, current_time_step, iv, unk_name, unk,
                                   iso_value);
       }
 
-      // Integral
+      // Integral : control at the uppest level of the scheme; automatically disable if Problem's
+      // variables are not given
       if (!map_integral.empty() && map_integral.contains(unk_name)) {
         const auto& [lower_bound, upper_bound] = map_integral.at(unk_name);
         this->oper_.ComputeIntegral(iter, current_time, current_time_step, iv, unk_name, unk,
@@ -570,8 +559,8 @@ void Problem<OPE, VAR, PST>::post_processing(const int& iter, const double& curr
       this->oper_.ComputeEnergies(iter, current_time, current_time_step, u_vect);
     }
   }
-  // Save variables for visualization
-  ProblemBase<VAR, PST>::post_processing(iter, current_time);
+  // // Save variables for visualization
+  // ProblemBase<VAR, PST>::post_processing(iter, current_time);
 
   // Save specialized values at each time-step if required
   if (this->has_pst()) {

--- a/kernel/include/Problems/ProblemBase.hpp
+++ b/kernel/include/Problems/ProblemBase.hpp
@@ -89,6 +89,7 @@ class ProblemBase {
   std::vector<std::tuple<std::string, bool, double>> var_convergence_;
 
   AMRBase<VAR>* amr_{nullptr};
+  bool enable_time_specialized_{true};
 
  public:
   using VarType = VAR;
@@ -137,6 +138,8 @@ class ProblemBase {
     return pst_->get();
   }
 
+  bool disableTimeSpecialized() { this->enable_time_specialized_ = false; };
+
   //
 
   virtual ~ProblemBase() = default;
@@ -165,12 +168,16 @@ class ProblemBase {
 
   void update();
 
-  virtual void post_processing(const int& iter, const double& current_time);
+  void post_processing(const int& iter, const double& current_time, bool vtk_unified);
+  void save_vtk(const int iter, const double& current_time);
 
-  virtual void save(const int iter, const double& current_time);
+  virtual void save_csv(const int iter, const double current_time) {}
 
   virtual void finalize();
   virtual void set_time_coefficients(double) {}
+
+  void collect_vtk_fields(std::map<std::string, mfem::ParGridFunction*>& all_fields);
+  auto get_shared_dc() { return this->pst_->get().get_shared_dc(); }
 };
 
 #include "Problems/ProblemBase.tpp"

--- a/kernel/include/Problems/ProblemBase.tpp
+++ b/kernel/include/Problems/ProblemBase.tpp
@@ -406,29 +406,15 @@ void ProblemBase<VAR, PST>::finalize() {
  * @param current_time_step Current time-step.
  */
 template <class VAR, class PST>
-void ProblemBase<VAR, PST>::post_processing(const int& iter, const double& current_time) {
+void ProblemBase<VAR, PST>::post_processing(const int& iter, const double& current_time,
+                                            bool vtk_unified) {
   // Save for visualization
-  this->save(iter, current_time);
-}
+  this->save_csv(iter, current_time);
 
-/**
- * @brief Main actions done during a time-step
- *
- * @tparam VAR Type representing the problem Variables.
- * @tparam PST Type representing the post-processing.
- * @param next_time Next simulation time (Current time+ current time step).
- * @param current_time Current simulation time.
- * @param current_time_step Current time-step.
- * @param iter Current iteration number.
- * @param unks Unknown at the current time-step.
- * @param unks_info Additionnal informations associated with the unkwon of the Problem.
- */
-// template <class VAR, class PST>
-// void ProblemBase<VAR, PST>::do_time_step(double& next_time, const double& current_time,
-//                                          double current_time_step, const int iter,
-//                                          std::vector<std::unique_ptr<mfem::Vector>>& unks,
-//                                          const std::vector<std::vector<std::string>>& unks_info)
-//                                          {}
+  if (!vtk_unified) {
+    this->save_vtk(iter, current_time);
+  }
+}
 
 /**
  * @brief Check convergence of variables at the current time-step
@@ -469,7 +455,8 @@ void ProblemBase<VAR, PST>::check_convergence(
 }
 
 /**
- * @brief Save variables
+ * @brief Save variables in VTK files,
+ *        if a PostProcessing object is attached.
  *
  * @tparam VAR Type representing the problem Variables.
  * @tparam PST Type representing the post-processing.
@@ -477,7 +464,7 @@ void ProblemBase<VAR, PST>::check_convergence(
  * @param current_time Current simulation time.
  */
 template <class VAR, class PST>
-void ProblemBase<VAR, PST>::save(const int iter, const double& current_time) {
+void ProblemBase<VAR, PST>::save_vtk(const int iter, const double& current_time) {
   if (this->has_pst()) {
     auto vars = this->get_problem_variables();
     this->get_pst().save_variables(vars, iter, current_time);
@@ -546,5 +533,22 @@ void ProblemBase<VAR, PST>::save_amr(const std::vector<VAR*>& all_vars) {
   if (this->amr_ != nullptr) {
     this->amr_->StepDerefine(this->variables_, all_vars);
     this->amr_->StepRefine(this->variables_, all_vars);
+  }
+}
+
+/**
+ * @brief Collect this Problem's grid functions into a shared field map,
+ *        if a PostProcessing object is attached.
+ *
+ * @tparam VAR Type representing the problem Variables.
+ * @tparam PST Type representing the post-processing.
+ * @param all_fields Output map, accumulated across every Problem for a
+ *                   unified VTK save (see `Coupling`/`TimeDiscretization`).
+ */
+template <class VAR, class PST>
+void ProblemBase<VAR, PST>::collect_vtk_fields(
+    std::map<std::string, mfem::ParGridFunction*>& all_fields) {
+  if (this->has_pst()) {
+    this->get_pst().collect_vtk_fields(this->variables_, all_fields);
   }
 }

--- a/kernel/include/Time/Time.hpp
+++ b/kernel/include/Time/Time.hpp
@@ -83,9 +83,10 @@ class TimeDiscretization {
   void check_duplicate_post_processing_directory();
   std::function<double(double)> time_step_function_;
   std::vector<VAR*> CollectAllVariables();
+  bool vtk_unified_{false};
+  void save_vtk_unified(const int& iter, const double& current_time);
 
  public:
-  // explicit TimeDiscretization(const Parameters& params, Args&&... couplings);
   explicit TimeDiscretization(const Parameters& params, Args... couplings);
   explicit TimeDiscretization(const std::function<double(double)>& given_time_step,
                               const Parameters& params, Args... couplings);

--- a/kernel/include/Time/Time.tpp
+++ b/kernel/include/Time/Time.tpp
@@ -73,6 +73,9 @@ TimeDiscretization<Args...>::TimeDiscretization(
     : params_(params), couplings_(std::make_tuple(std::forward<Args>(couplings)...)) {
   this->get_parameters();
   this->time_step_function_ = given_time_step;
+
+  this->check_duplicate_coupling_name();
+  this->check_duplicate_post_processing_directory();
 }
 
 /**
@@ -83,6 +86,8 @@ TimeDiscretization<Args...>::TimeDiscretization(
  */
 template <class... Args>
 void TimeDiscretization<Args...>::get_parameters() {
+  this->vtk_unified_ =
+      this->params_.template get_param_value_or_default<bool>("vtk_unified", false);
   this->initial_time_ =
       this->params_.template get_param_value_or_default<double>("initial_time", 0.);
   this->initial_iter_ =
@@ -133,9 +138,15 @@ void TimeDiscretization<Args...>::initialize() {
   this->current_time_ = tt;
   const auto& iter = this->initial_iter_;
   auto all_vars = this->CollectAllVariables();
-  std::apply([iter, tt, dt,
-              all_vars](auto&... coupling) { (coupling.initialize(iter, tt, dt, all_vars), ...); },
-             couplings_);
+  std::apply(
+      [this, iter, tt, dt, all_vars](auto&... coupling) {
+        (coupling.initialize(iter, tt, dt, this->vtk_unified_, all_vars), ...);
+      },
+      couplings_);
+
+  if (this->vtk_unified_) {
+    this->save_vtk_unified(iter, this->current_time_);
+  }
 }
 
 /**
@@ -179,10 +190,14 @@ void TimeDiscretization<Args...>::post_processing(const int& iter) {
   auto all_vars = this->CollectAllVariables();
 
   std::apply(
-      [iter, current_time, all_vars](auto&... coupling) {
-        (coupling.post_processing(iter, current_time, all_vars), ...);
+      [this, iter, current_time, all_vars](auto&... coupling) {
+        (coupling.post_processing(iter, current_time, this->vtk_unified_, all_vars), ...);
       },
       couplings_);
+
+  if (this->vtk_unified_) {
+    this->save_vtk_unified(iter, current_time);
+  }
 }
 
 /**
@@ -323,11 +338,51 @@ void TimeDiscretization<Args...>::check_duplicate_coupling_name() {
 template <class... Args>
 void TimeDiscretization<Args...>::check_duplicate_post_processing_directory() {
   const std::size_t nb_couplings = std::tuple_size_v<decltype(couplings_)>;
+  std::map<std::string, int> directory_count;
+
   std::apply(
       [&](auto&... coupling) {
-        (coupling.check_duplicate_post_processing_directory(nb_couplings), ...);
+        (coupling.get_post_processing_directory_count(directory_count), ...);
       },
       couplings_);
+
+  std::apply(
+      [&](auto&... coupling) {
+        (coupling.check_duplicate_post_processing_directory(nb_couplings, directory_count), ...);
+      },
+      couplings_);
+}
+
+/**
+ * @brief Perform a single unified VTK save across every Problem in every
+ *        Coupling.
+ *
+ * @details No-op unless `vtk_unified` was enabled (see the
+ *          `Parameters`-based constructor). Collects every Problem's
+ *          fields into a single map before registering and saving them
+ *          all at once through the DataCollection shared by the first
+ *          Coupling
+ *
+ * @tparam Args Coupling types in this simulation.
+ * @param iter Current iteration number.
+ * @param current_time Current simulation time.
+ */
+template <class... Args>
+void TimeDiscretization<Args...>::save_vtk_unified(const int& iter, const double& current_time) {
+  if (!this->vtk_unified_) return;
+
+  std::map<std::string, mfem::ParGridFunction*> all_fields;
+
+  std::apply([&all_fields](auto&... coupling) { (coupling.collect_vtk_fields(all_fields), ...); },
+             this->couplings_);
+
+  auto dc = std::get<0>(this->couplings_).get_shared_dc();
+  dc->SetCycle(iter);
+  dc->SetTime(current_time);
+  for (auto& [name, gf_ptr] : all_fields) {
+    dc->RegisterField(name, gf_ptr);
+  }
+  dc->Save();
 }
 
 /**

--- a/kernel/include/Utils/UtilsForData.hpp
+++ b/kernel/include/Utils/UtilsForData.hpp
@@ -119,6 +119,19 @@ inline std::string replaceSpaces(std::string str) {
 
   return str;
 }
+/**
+ * @brief Replaces punctuation characters with underscores.
+ *
+ * @param str The input string.
+ * @return A copy of the input string with punctuation replaced by `_`
+ *
+ */
+inline std::string replacePunctuation(std::string str) {
+  std::ranges::replace_if(
+      str, [](char c) { return std::ispunct(static_cast<unsigned char>(c)); }, '_');
+
+  return str;
+}
 
 /////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////

--- a/kernel/include/Variables/Variables.hpp
+++ b/kernel/include/Variables/Variables.hpp
@@ -55,7 +55,7 @@ class Variables {
   std::vector<Variable<T, DIM>> getVariables() const;
   size_t get_variables_number() const;
   Variable<T, DIM>& get_variable(const std::string& name);
-  std::map<std::string, mfem::ParGridFunction> get_map_gridfunction() const;
+  std::map<std::string, mfem::ParGridFunction*> get_map_gridfunction();
   std::map<std::string, Variable<T, DIM>> get_map_variable() const;
   ~Variables();
 };

--- a/kernel/include/Variables/Variables.tpp
+++ b/kernel/include/Variables/Variables.tpp
@@ -103,12 +103,11 @@ Variable<T, DIM>& Variables<T, DIM>::operator[](size_t i) {
  * @return std::map<std::string, mfem::ParGridFunction>
  */
 template <class T, int DIM>
-std::map<std::string, mfem::ParGridFunction> Variables<T, DIM>::get_map_gridfunction() const {
-  std::map<std::string, mfem::ParGridFunction> map_var;
-  for (auto vv : this->vect_variables_) {
+std::map<std::string, mfem::ParGridFunction*> Variables<T, DIM>::get_map_gridfunction() {
+  std::map<std::string, mfem::ParGridFunction*> map_var;
+  for (auto& vv : this->vect_variables_) {
     const std::string& name = vv.getVariableName();
-    auto gf = vv.get_gf();
-    map_var.try_emplace(name, gf);
+    map_var.try_emplace(name, &vv.get_ref_gf());
   }
   return map_var;
 }

--- a/kernel/src/AMR/SlothErrorEstimators.cpp
+++ b/kernel/src/AMR/SlothErrorEstimators.cpp
@@ -72,27 +72,33 @@ std::shared_ptr<mfem::ErrorEstimator> SlothErrorEstimators::get_value(
     mfem::ParGridFunction& x, mfem::ParFiniteElementSpace& fespace, mfem::ParMesh& mesh) {
   switch (this->value_) {
     case ErrorEstimatorType::L2_ZIENKIEWICZ_ZHU: {
-      MFEM_VERIFY(this->integ_ != nullptr,
-                  "SlothErrorEstimators: L2_ZIENKIEWICZ_ZHU requires a BilinearFormIntegrator, "
-                  "pass one via the (type, integ) constructor.");
-
       const int order = fespace.GetOrder(0);
-      this->flux_fes_ = new mfem::ParFiniteElementSpace(
-          &mesh, new mfem::L2_FECollection(order, mesh.Dimension()), mesh.SpaceDimension());
-      this->smooth_flux_fes_ = new mfem::ParFiniteElementSpace(
-          &mesh, new mfem::RT_FECollection(order - 1, mesh.Dimension()));
+
+      delete this->flux_fec_;
+      delete this->smooth_flux_fec_;
+
+      this->flux_fec_ = new mfem::L2_FECollection(order, mesh.Dimension());
+      this->smooth_flux_fec_ = new mfem::RT_FECollection(order - 1, mesh.Dimension());
+
+      this->flux_fes_ =
+          new mfem::ParFiniteElementSpace(&mesh, this->flux_fec_, mesh.SpaceDimension());
+      this->smooth_flux_fes_ = new mfem::ParFiniteElementSpace(&mesh, this->smooth_flux_fec_);
+
       return std::make_shared<mfem::L2ZienkiewiczZhuEstimator>(*this->integ_, x, this->flux_fes_,
                                                                this->smooth_flux_fes_);
-      break;
     }
     case ErrorEstimatorType::KELLY: {
-      MFEM_VERIFY(this->integ_ != nullptr,
-                  "SlothErrorEstimators: KELLY requires a BilinearFormIntegrator.");
+      MFEM_VERIFY(this->integ_ != nullptr, "...");
       const int order = fespace.GetOrder(0);
-      this->flux_fes_ = new mfem::ParFiniteElementSpace(
-          &mesh, new mfem::L2_FECollection(order, mesh.Dimension()), mesh.SpaceDimension());
+
+      delete this->flux_fec_;
+
+      this->flux_fec_ = new mfem::L2_FECollection(order, mesh.Dimension());
+
+      this->flux_fes_ =
+          new mfem::ParFiniteElementSpace(&mesh, this->flux_fec_, mesh.SpaceDimension());
+
       return std::make_shared<mfem::KellyErrorEstimator>(*this->integ_, x, this->flux_fes_);
-      break;
     }
     default:
       mfem::mfem_error("SlothEstimator::get_value: unknown estimator type.");
@@ -121,4 +127,7 @@ void SlothErrorEstimators::UpdateFluxSpaces() {
  * @brief Destroy the SlothErrorEstimators object
  *
  */
-SlothErrorEstimators::~SlothErrorEstimators() {}
+SlothErrorEstimators::~SlothErrorEstimators() {
+  delete this->flux_fec_;
+  delete this->smooth_flux_fec_;
+}


### PR DESCRIPTION
- get_map_gridfunction() now returns pointers to persistent GridFunctions instead of fresh copies.
- Added a collect_vtk_fields() chain (PostProcessing -> Problem -> Coupling -> TimeDiscretization) so every Problem's fields are gathered once and saved in a single Save() call (TimeDiscretization::save_vtk_unified(), opt-in via `vtk_unified`).
- ProblemBase::post_processing() skips its own save_vtk() when vtk_unified is active.
- Fixed a leak in SlothErrorEstimators::get_value(): the FECollection built on every call was never freed (ParFiniteElementSpace doesn't own it).